### PR TITLE
Disable description label

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,5 +1,5 @@
 name: "jboss-datagrid-7/datagrid71-openshift"
-description: "Red Hat JBoss Data Grid 7.1 for OpenShift container image"
+# description: "Red Hat JBoss Data Grid 7.1 for OpenShift container image"
 version: "1.0"
 from: "jboss-datagrid-7/datagrid71:latest"
 user: 185


### PR DESCRIPTION
This is a workaround for building in OSBS. The description
label will be populated at the build time with io.k8s.description
label content.