### PR TITLE
bump dogen version to 2.4.0

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -272,7 +272,7 @@ cct:
           - cct_module.openshift-layer:
                 - configure_passwd_sh:
 dogen:
-    version: 2.3.0
+    version: 2.4.0
     plugins:
         cct:
             verbose: true


### PR DESCRIPTION
This is necessary for the dist-git plugin to recognise the situation
where there are no source changes in the image source repo, but the
referenced cct module has changed.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>