### PR TITLE
Bump dogen version to 2.4.1

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -272,7 +272,7 @@ cct:
           - cct_module.openshift-layer:
                 - configure_passwd_sh:
 dogen:
-    version: 2.4.0
+    version: 2.4.1
     plugins:
         cct:
             verbose: true


### PR DESCRIPTION
Fixes a build issue relating to pykwalify missing in the container
(a cct prerequisite)

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>