### PR TITLE
[CLOUD-2008] re-enable description: label

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,5 +1,5 @@
 name: "jboss-datagrid-7/datagrid71-openshift"
-# description: "Red Hat JBoss Data Grid 7.1 for OpenShift container image"
+description: "Red Hat JBoss Data Grid 7.1 for OpenShift container image"
 version: "1.1"
 from: "jboss-datagrid-7/datagrid71:latest"
 user: 185


### PR DESCRIPTION
This was disabled originally to work around a bug in our image builder which has since
been resolved. Re-enabling this label will also result in the images gaining a summary
label, overriding any provided by base images.

https://issues.jboss.org/browse/CLOUD-2008

----

- [✔] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [✔] Pull Request contains link to the JIRA issue
- [✔] Pull Request contains description of the issue
- [✔] Pull Request does not include fixes for issues other than the main ticket
- [✔] Attached commits represent units of work and are properly formatted
- [✔] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [✔] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`