### PR TITLE
Use dev image for 7.2

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-datagrid-7/datagrid72-openshift"
 description: "Red Hat JBoss Data Grid 7.2 for OpenShift container image"
 version: "1.0"
-from: "jboss-datagrid-7/datagrid72:latest"
+from: "jboss-datagrid-7/datagrid72:dev"
 labels:
     - name: "io.k8s.description"
       value: "Provides a scalable in-memory distributed database designed for fast access to large volumes of data."


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-8479

The idea of "more agile" approach for JDG 7.2 development (and JDG Online Services) is to be able to use SNAPSHOT server builds. JDG 7.2 Standalone image already supports it but all builds are done for `dev` tag. We need to consume it here, to produce base image for all JDG Online Services.