### PR TITLE
Creates override files for building from each branch (ga/cp/dev)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -139,7 +139,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-14
+                  ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -1,0 +1,11 @@
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: sprint-15
+
+osbs:
+    repository:
+        name: containers/jboss-datagrid-7
+        branch: jb-datagrid-7.1-openshift-cp-rhel-7

--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -1,0 +1,11 @@
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: sprint-18
+
+osbs:
+    repository:
+        name: containers/jboss-datagrid-7
+        branch: jb-datagrid-7.1-openshift-dev-rhel-7

--- a/override-ga.yaml
+++ b/override-ga.yaml
@@ -1,0 +1,11 @@
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: sprint-15
+
+osbs:
+    repository:
+        name: containers/jboss-datagrid-7
+        branch: jb-datagrid-7.1-openshift-rhel-7


### PR DESCRIPTION
The override files are used to point to the correct cct_modules branch when building, and also to sync with the appropriate dist-git branch for each kind of build (ga/cp/dev).

Obs: after releasing from the ga branch, this code should be merged into both -cp and -dev, so it can be used for any kind of build, also avoiding future merge conflicts.

Signed-off-by: Osni Oliveira <osni.oliveira@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

~- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`~
~- [ ] Pull Request contains link to the JIRA issue~
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
