### PR TITLE
[CLOUD-2157] missing description for ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH parameter in templates

### DIFF
--- a/templates/datagrid72-https.json
+++ b/templates/datagrid72-https.json
@@ -149,7 +149,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false

--- a/templates/datagrid72-mysql-persistent.json
+++ b/templates/datagrid72-mysql-persistent.json
@@ -234,7 +234,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false

--- a/templates/datagrid72-mysql.json
+++ b/templates/datagrid72-mysql.json
@@ -227,7 +227,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false

--- a/templates/datagrid72-partition.json
+++ b/templates/datagrid72-partition.json
@@ -86,7 +86,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false

--- a/templates/datagrid72-postgresql-persistent.json
+++ b/templates/datagrid72-postgresql-persistent.json
@@ -216,7 +216,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false

--- a/templates/datagrid72-postgresql.json
+++ b/templates/datagrid72-postgresql.json
@@ -209,7 +209,7 @@
         },
         {
             "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
+            "description": "Whether to require client certificate authentication. Defaults to false",
             "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
             "value": "",
             "required": false


### PR DESCRIPTION
*Do not integrate yet* @tristantarrant please have a look. Not sure if we need to explicitly specify the default value for this parameter i.e. false. Do you know @ryanemerson ?