### PR TITLE
[CLOUD-1367] Parameter ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH never used in practice

### DIFF
--- a/templates/datagrid72-basic.json
+++ b/templates/datagrid72-basic.json
@@ -113,13 +113,6 @@
             "required": false
         },
         {
-            "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "",
-            "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
-            "value": "",
-            "required": false
-        },
-        {
             "displayName": "Memcached Cache Name",
             "description": "The name of the cache to expose through this memcached connector",
             "name": "MEMCACHED_CACHE",
@@ -426,10 +419,6 @@
                                     {
                                         "name": "CACHE_TYPE_DEFAULT",
                                         "value": "${CACHE_TYPE_DEFAULT}"
-                                    },
-                                    {
-                                        "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
-                                        "value": "${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}"
                                     },
                                     {
                                         "name": "HOTROD_SERVICE_NAME",

--- a/templates/datagrid72-partition.json
+++ b/templates/datagrid72-partition.json
@@ -85,13 +85,6 @@
             "required": false
         },
         {
-            "displayName": "Encryption Requires SSL Client Authentication?",
-            "description": "Whether to require client certificate authentication. Defaults to false",
-            "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
-            "value": "",
-            "required": false
-        },
-        {
             "displayName": "Memcached Cache Name",
             "description": "The name of the cache to expose through this memcached connector",
             "name": "MEMCACHED_CACHE",
@@ -459,10 +452,6 @@
                                     {
                                         "name": "CACHE_TYPE_DEFAULT",
                                         "value": "${CACHE_TYPE_DEFAULT}"
-                                    },
-                                    {
-                                        "name": "ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH",
-                                        "value": "${ENCRYPTION_REQUIRE_SSL_CLIENT_AUTH}"
                                     },
                                     {
                                         "name": "HOTROD_SERVICE_NAME",


### PR DESCRIPTION
*Do not integrate* yet. We need @tristantarrant and @ryanemerson to review this one. To get a full context about CLOUD-1367 see CLOUD-1448 and CLOUD-2157. See https://github.com/jboss-container-images/jboss-datagrid-7-openshift-image/pull/67 for more details. 