### PR TITLE
CLOUD-2394 [JDG72] Catch up on Data Grid 7.2 default server configuration

### DIFF
--- a/modules/datagrid/72/configuration/added/clustered-openshift.xml
+++ b/modules/datagrid/72/configuration/added/clustered-openshift.xml
@@ -85,7 +85,7 @@
             </periodic-rotating-file-handler>
             <size-rotating-file-handler name="HR-ACCESS-FILE" autoflush="true">
                 <formatter>
-                    <pattern-formatter pattern="(%t) %s%e%n"/>
+                    <named-formatter name="ACCESS-LOG"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="hotrod-access.log"/>
                 <append value="true"/>
@@ -94,7 +94,7 @@
             </size-rotating-file-handler>
             <size-rotating-file-handler name="REST-ACCESS-FILE" autoflush="true">
                 <formatter>
-                    <pattern-formatter pattern="(%t) %s%e%n"/>
+                    <named-formatter name="ACCESS-LOG"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="rest-access.log"/>
                 <append value="true"/>
@@ -104,23 +104,25 @@
             <logger category="com.arjuna">
                 <level name="WARN"/>
             </logger>
-            <logger category="org.apache.tomcat.util.modeler">
-                <level name="WARN"/>
-            </logger>
             <logger category="org.jboss.as.config">
                 <level name="DEBUG"/>
             </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>
-            <logger category="jacorb">
-                <level name="WARN"/>
+            <logger category="org.infinispan.HOTROD_ACCESS_LOG" use-parent-handlers="false">
+                <!-- Set to TRACE to enable access logging for hot rod or use DMR -->
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="HR-ACCESS-FILE"/>
+                </handlers>
             </logger>
-            <logger category="jacorb.config">
-                <level name="ERROR"/>
-            </logger>
-            <logger category="org.infinispan.rest.embedded.netty4.i18n">
-                <level name="WARN"/>
+            <logger category="org.infinispan.REST_ACCESS_LOG" use-parent-handlers="false">
+                <!-- Set to TRACE to enable access logging for rest or use DMR -->
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="REST-ACCESS-FILE"/>
+                </handlers>
             </logger>
             <!-- ##ACCESS_LOG_HANDLER## -->
             <root-logger>
@@ -141,6 +143,9 @@
             </formatter>
             <formatter name="COLOR-PATTERN">
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            </formatter>
+            <formatter name="ACCESS-LOG">
+                <pattern-formatter pattern="%X{address} %X{user} [%d{dd/MMM/yyyy:HH:mm:ss z}] &quot;%X{method} %m %X{protocol}&quot; %X{status} %X{requestSize} %X{responseSize} %X{duration}%n"/>
             </formatter>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">

--- a/modules/datagrid/72/launch/added/launch/cache-container.xml
+++ b/modules/datagrid/72/launch/added/launch/cache-container.xml
@@ -10,6 +10,19 @@
                 <distributed-cache-configuration name="indexed">
                     <indexing index="LOCAL" auto-config="true"/>
                 </distributed-cache-configuration>
+                <distributed-cache-configuration name="memory-bounded">
+                    <memory>
+                        <object size="10000"/>
+                    </memory>
+                </distributed-cache-configuration>
+                <distributed-cache-configuration name="persistent-file-store-passivation">
+                    <memory>
+                        <object size="10000"/>
+                    </memory>
+                    <file-store shared="false" fetch-state="true" passivation="true">
+                        <write-behind modification-queue-size="1024" thread-pool-size="1"/>
+                    </file-store>
+                </distributed-cache-configuration>
                 <distributed-cache-configuration name="persistent-file-store-write-behind">
                     <file-store shared="false" fetch-state="true" passivation="false">
                         <write-behind modification-queue-size="1024" thread-pool-size="1"/>


### PR DESCRIPTION
Fixes [CLOUD-2394](https://issues.jboss.org/browse/CLOUD-2394) [JDG72] Catch up on Data Grid 7.2 default server configuration. We have an outdated JDG configuration that needs to be updated to match the latest JDG 7.2 default configuration. Please review @ryanemerson 




