### PR TITLE
[CLOUD-2769] [JDG72] Enable new memory eviction configuration

### DIFF
--- a/modules/datagrid/72/launch/added/launch/infinispan-config.sh
+++ b/modules/datagrid/72/launch/added/launch/infinispan-config.sh
@@ -520,10 +520,18 @@ function configure_jdbc_store() {
           ;;
       esac
     fi
-    if [ -n "$(find_env "${prefix}_CACHE_EVICTION_STRATEGY")" -a "$(find_env "${prefix}_CACHE_EVICTION_STRATEGY")" != "NONE" ]; then
-      JDBC_STORE_PASSIVATION=true
-    else
-      JDBC_STORE_PASSIVATION=false
+    if [ -n "$(find_env "${prefix}_CACHE_MEMORY_EVICTION_SIZE")$(find_env "${prefix}_CACHE_EVICTION_MAX_ENTRIES")" ]; then
+      local evictionSize="$(find_env "${prefix}_CACHE_MEMORY_EVICTION_SIZE")"
+      if [ -n "$(find_env "${prefix}_CACHE_EVICTION_MAX_ENTRIES")" ]; then
+        if [ -z "$(find_env "${prefix}_CACHE_MEMORY_EVICTION_SIZE")" ]; then
+          evictionSize="$(find_env "${prefix}_CACHE_EVICTION_MAX_ENTRIES")"
+        fi
+      fi 
+      if [ "$evictionSize" -gt "0" ]; then
+        JDBC_STORE_PASSIVATION=true 
+      else
+        JDBC_STORE_PASSIVATION=false
+      fi
     fi
 
     jdbcstore="\

--- a/modules/datagrid/72/launch/added/launch/infinispan-config.sh
+++ b/modules/datagrid/72/launch/added/launch/infinispan-config.sh
@@ -286,7 +286,7 @@ function configure_cache() {
 
     local evictionSize="$(find_env "${prefix}_CACHE_MEMORY_EVICTION_SIZE")"
     if [ -n "$(find_env "${prefix}_CACHE_EVICTION_MAX_ENTRIES")" ]; then
-      log_warning "Environment variable {$prefix}_CACHE_EVICTION_MAX_ENTRIES has been deprecated. Use {$prefix}_CACHE_MEMORY_EVICTION_SIZE instead."
+      log_warning "Environment variable ${prefix}_CACHE_EVICTION_MAX_ENTRIES has been deprecated. Use ${prefix}_CACHE_MEMORY_EVICTION_SIZE instead."
       if [ -z "$(find_env "${prefix}_CACHE_MEMORY_EVICTION_SIZE")" ]; then
       	evictionSize="$(find_env "${prefix}_CACHE_EVICTION_MAX_ENTRIES")"
       fi


### PR DESCRIPTION
Introduces new <memory> eviction configuration and accompanying per cache environmental variables. More details at https://issues.jboss.org/browse/CLOUD-2769