### PR TITLE
CLOUD-2799 Updates for releasing Data Grid 7.2 OpenShift image v1.1

### DIFF
--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -3,7 +3,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-20
+                  ref: sprint-22
 
 osbs:
     repository:

--- a/templates/datagrid72-basic.json
+++ b/templates/datagrid72-basic.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using using ephemeral (temporary) storage and communication using http.",
+            "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using ephemeral (temporary) storage and communication using http.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-basic"
     },
     "labels": {
-        "template": "datagrid72-basic",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-basic"
     },
     "message": "A new data grid service has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\".",
     "parameters": [
@@ -284,7 +283,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-https.json
+++ b/templates/datagrid72-https.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using using ephemeral (temporary) storage and secure communication using https.",
+            "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-https"
     },
     "labels": {
-        "template": "datagrid72-https",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-https"
     },
     "message": "A new data grid service has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -401,7 +400,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-image-stream.json
+++ b/templates/datagrid72-image-stream.json
@@ -16,7 +16,8 @@
                 "name": "jboss-datagrid72-openshift",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2",
-                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.1"
                 }
             },
             "spec": {
@@ -34,6 +35,21 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid72-openshift:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "description": "Red Hat JBoss Data Grid 7.2 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:7.2",
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.access.redhat.com/jboss-datagrid-7/datagrid72-openshift:1.1"
                         }
                     }
                 ]

--- a/templates/datagrid72-mysql-persistent.json
+++ b/templates/datagrid72-mysql-persistent.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 + MySQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using MySQL databased using persistence and secure communication using https.",
+            "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using MySQL database for persistence and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-mysql-persistent"
     },
     "labels": {
-        "template": "datagrid72-mysql-persistent",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-mysql-persistent"
     },
     "message": "A new data grid service (using MySQL with persistent storage) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -521,7 +520,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-mysql.json
+++ b/templates/datagrid72-mysql.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 + MySQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using MySQL databased using ephemeral (temporary) storage and secure communication using https.",
+            "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using MySQL database with ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-mysql"
     },
     "labels": {
-        "template": "datagrid72-mysql",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-mysql"
     },
     "message": "A new data grid service (using MySQL) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -514,7 +513,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-partition.json
+++ b/templates/datagrid72-partition.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using using ephemeral (temporary) storage and communication using http.",
+            "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using ephemeral (temporary) storage and communication using http.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-partition"
     },
     "labels": {
-        "template": "datagrid72-partition",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-partition"
     },
     "message": "A new data grid service has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\".",
     "parameters": [
@@ -322,7 +321,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-postgresql-persistent.json
+++ b/templates/datagrid72-postgresql-persistent.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 + PostgreSQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using PostgreSQL database using persistence and secure communication using https.",
+            "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using PostgreSQL database for persistence and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-postgresql-persistent"
     },
     "labels": {
-        "template": "datagrid72-postgresql-persistent",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-postgresql-persistent"
     },
     "message": "A new data grid service (using PostgreSQL with persistent storage) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -501,7 +500,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },

--- a/templates/datagrid72-postgresql.json
+++ b/templates/datagrid72-postgresql.json
@@ -5,19 +5,18 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4.12",
+            "version": "1.1",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 + PostgreSQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
-            "description": "An exampleRed Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
-            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based application, including a deployment configuration, using PostgreSQL database using ephemeral (temporary) storage and secure communication using https.",
+            "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using PostgreSQL database with ephemeral (temporary) storage and secure communication using https.",
             "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
             "template.openshift.io/support-url": "https://access.redhat.com"
         },
         "name": "datagrid72-postgresql"
     },
     "labels": {
-        "template": "datagrid72-postgresql",
-        "xpaas": "1.4.12"
+        "template": "datagrid72-postgresql"
     },
     "message": "A new data grid service (using PostgreSQL) has been created in your project. It supports connector type(s) \"${INFINISPAN_CONNECTORS}\". The username/password for accessing the MySQL database \"${DB_DATABASE}\" is ${DB_USERNAME}/${DB_PASSWORD}. Please be sure to create the following secrets: \"${HTTPS_SECRET}\" containing the ${HTTPS_KEYSTORE} file used for serving secure content; \"${JGROUPS_ENCRYPT_SECRET}\" containing the ${JGROUPS_ENCRYPT_KEYSTORE} file used for securing JGroups communications.",
     "parameters": [
@@ -494,7 +493,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid72-openshift:1.0"
+                                "name": "jboss-datagrid72-openshift:1.1"
                             }
                         }
                     },


### PR DESCRIPTION
JIRA issue: [[CLOUD-2799] [DG7] Release Data Grid 7.2 version 1.1](https://issues.jboss.org/browse/CLOUD-2799)

This PR does the necessary updates for releasing the Data Grid 7.2 OpenShift image:
- Include modules from the sprint-22 branch (cct_modules repo)
- Update image stream definition with new 1.1 tag
- Update each template to use new 1.1 tag

~**IMPORTANT:** After merging this PR, it's necessary to create a new tag in this repo (1.1), so it can be referenced in the Errata/documentation instructing users on how to install/use the new released image and templates.~ - **DONE**

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
