### PR TITLE
Initial datagrid service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CEKIT_CMD = cekit build --target target-docker --tag $(DEV_IMAGE_FULL_NAME)
 endif
 
 DOCKER_MEMORY=512M
-MVN_COMMAND = mvn
+MVN_COMMAND = mvn -s services/functional-tests/maven-settings.xml
 _TEST_PROJECT = myproject
 
 #Set variables for remote openshift when OPENSHIFT_ONLINE_REGISTRY is defined

--- a/docs/datagrid-service.asciidoc
+++ b/docs/datagrid-service.asciidoc
@@ -1,0 +1,3 @@
+= Red Hat Data Grid Service
+
+TODO

--- a/modules/datagrid/72/launch/added/launch/cache-container.xml
+++ b/modules/datagrid/72/launch/added/launch/cache-container.xml
@@ -1,4 +1,3 @@
-                <global-state/>
                 <distributed-cache-configuration name="transactional">
                     <transaction mode="NON_XA" locking="PESSIMISTIC"/>
                 </distributed-cache-configuration>

--- a/modules/datagrid/72/launch/added/launch/infinispan-config.sh
+++ b/modules/datagrid/72/launch/added/launch/infinispan-config.sh
@@ -228,7 +228,14 @@ function configure_infinispan_core() {
   local containers="<cache-container name=\"clustered\" default-cache=\"$DEFAULT_CACHE\" $cache_container_start $cache_container_statistics>"
   containers="$containers $transport"
   local cache_container_configuration=$(cat "${CACHE_CONTAINER_FILE}" | sed ':a;N;$!ba;s|\n|\\n|g')
-  containers="$containers ${cache_container_configuration}"
+
+  if [ "$(find_env "$ENABLE_OVERLAY_CONFIGURATION_STORAGE")" == "true" ]; then
+    global_state="<global-state><overlay-configuration-storage/></global-state>"
+  else
+    global_state="<global-state/>"
+  fi
+
+  containers="$containers $global_state ${cache_container_configuration}"
   containers="$containers $containersecurity <!-- ##INFINISPAN_CACHE## --></cache-container>"
 
   sed -i "s|<!-- ##INFINISPAN_CORE## -->|$containers|" "$CONFIG_FILE"

--- a/modules/datagrid/72/launch/added/launch/infinispan_service_profiles.sh
+++ b/modules/datagrid/72/launch/added/launch/infinispan_service_profiles.sh
@@ -53,6 +53,23 @@ function configure() {
          # EVICTION_TOTAL_MEMORY_B exported by adjust_memory.sh
          source ${JBOSS_HOME}/bin/launch/adjust_memory.sh
          export DEFAULT_CACHE_MEMORY_EVICTION_SIZE=${EVICTION_TOTAL_MEMORY_B}
+      elif [ "${SERVICE_PROFILE}" == "datagrid-service" ]; then
+         SERVICE_NAME=${SERVICE_NAME:-datagrid-service}
+
+         createKeystoresFromSecrets
+
+         # Endpoints
+         export INFINISPAN_CONNECTORS="hotrod,rest"
+         export HOTROD_AUTHENTICATION="TRUE"
+         export HOTROD_ENCRYPTION="TRUE"
+         export REST_SECURITY_DOMAIN="ApplicationRealm"
+
+         # Infinispan
+         export DEFAULT_CACHE_OWNERS="2"
+         export DEFAULT_CACHE_PARTITION_HANDLING_WHEN_SPLIT="DENY_READ_WRITES"
+         export DEFAULT_CACHE_PARTITION_HANDLING_MERGE_POLICY="REMOVE_ALL"
+         export DEFAULT_CACHE_MEMORY_STORAGE_TYPE="off-heap"
+         export ENABLE_OVERLAY_CONFIGURATION_STORAGE="true"
       fi
    fi
 }

--- a/services/datagrid-service.json
+++ b/services/datagrid-service.json
@@ -1,0 +1,357 @@
+{
+   "apiVersion": "v1",
+   "kind": "Template",
+   "labels": {
+      "template": "datagrid-service"
+   },
+   "metadata": {
+      "annotations": {
+         "description": "Red Hat Data Grid is a high performance, linearly scalable, key/value data grid solution. It provides many features to serve a variety of use cases.",
+         "iconClass": "icon-datagrid",
+         "tags": "database,datagrid",
+         "openshift.io/display-name": "Red Hat Data Grid Service",
+         "openshift.io/provider-display-name": "Red Hat, Inc.",
+         "openshift.io/documentation-url": "https://github.com/jboss-container-images/datagrid-7-image/blob/datagrid-services-dev/documentation/datagrid-service.asciidoc",
+         "openshift.io/long-description": "In this service, Red Hat Data Grid is configured as an in-memory data grid service.",
+         "openshift.io/support-url": "https://www.redhat.com/en/services/support"
+      },
+      "name": "datagrid-service"
+   },
+   "objects": [
+      {
+         "kind": "Secret",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}"
+         },
+         "stringData" : {
+            "application-user" : "${APPLICATION_USER}",
+            "application-password" : "${APPLICATION_USER_PASSWORD}"
+         }
+      },
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+            "annotations": {
+               "description": "Headless service for StatefulSets",
+               "service.alpha.openshift.io/serving-cert-secret-name": "service-certs"
+            },
+            "labels": {
+               "application": "${APPLICATION_NAME}"
+            },
+            "name": "${APPLICATION_NAME}-headless"
+         },
+         "spec": {
+            "ports": [
+               {
+                  "name": "http",
+                  "port": 8080,
+                  "targetPort": 8080
+               },
+               {
+                  "name": "hotrod",
+                  "port": 11222,
+                  "targetPort": 11222
+               }
+            ],
+            "selector": {
+               "deploymentConfig": "${APPLICATION_NAME}"
+            },
+            "clusterIP": "None"
+         }
+      },
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+            "annotations": {
+               "description": "The JGroups ping port for clustering.",
+               "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
+            },
+            "labels": {
+               "application": "${APPLICATION_NAME}"
+            },
+            "name": "${APPLICATION_NAME}-ping"
+         },
+         "spec": {
+            "ports": [
+               {
+                  "name": "ping",
+                  "port": 8888
+               }
+            ],
+            "selector": {
+               "deploymentConfig": "${APPLICATION_NAME}"
+            },
+            "clusterIP": "None"
+         }
+      },
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+            "annotations": {
+               "description": "The web server's HTTPS port."
+            },
+            "labels": {
+               "application": "${APPLICATION_NAME}"
+            },
+            "name": "${APPLICATION_NAME}-https"
+         },
+         "spec": {
+            "ports": [
+               {
+                  "port": 8080,
+                  "targetPort": 8443
+               }
+            ],
+            "selector": {
+               "deploymentConfig": "${APPLICATION_NAME}"
+            }
+         }
+      },
+      {
+         "apiVersion": "v1",
+         "kind": "Service",
+         "metadata": {
+            "annotations": {
+               "description": "Hot Rod's port."
+            },
+            "labels": {
+               "application": "${APPLICATION_NAME}"
+            },
+            "name": "${APPLICATION_NAME}-hotrod"
+         },
+         "spec": {
+            "ports": [
+               {
+                  "port": 11222,
+                  "targetPort": 11222
+               }
+            ],
+            "selector": {
+               "deploymentConfig": "${APPLICATION_NAME}"
+            }
+         }
+      },
+      {
+         "apiVersion": "apps/v1beta1",
+         "kind": "StatefulSet",
+         "metadata": {
+            "labels": {
+               "application": "${APPLICATION_NAME}"
+            },
+            "name": "${APPLICATION_NAME}"
+         },
+         "spec": {
+            "serviceName": "${APPLICATION_NAME}-headless",
+            "replicas": "${{NUMBER_OF_INSTANCES}}",
+            "strategy": {
+               "type": "Rolling",
+               "rollingParams": {
+                  "updatePeriodSeconds": 20,
+                  "intervalSeconds": 20,
+                  "timeoutSeconds": 1200,
+                  "maxUnavailable": 1,
+                  "maxSurge": 1
+               }
+            },
+            "template": {
+               "metadata": {
+                  "labels": {
+                     "application": "${APPLICATION_NAME}",
+                     "deploymentConfig": "${APPLICATION_NAME}"
+                  },
+                  "name": "${APPLICATION_NAME}"
+               },
+               "spec": {
+                  "containers": [
+                     {
+                        "env": [
+                           {
+                              "name": "SERVICE_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
+                              "name": "SERVICE_PROFILE",
+                              "value": "datagrid-service"
+                           },
+                           {
+                              "name": "JGROUPS_PING_PROTOCOL",
+                              "value": "openshift.DNS_PING"
+                           },
+                           {
+                              "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+                              "value": "${APPLICATION_NAME}-ping"
+                           },
+                           {
+                              "name": "USERNAME",
+                              "valueFrom": {
+                                 "secretKeyRef" : {
+                                    "name" : "${APPLICATION_NAME}",
+                                    "key" : "application-user"
+                                 }
+                              }
+                           },
+                           {
+                              "name": "PASSWORD",
+                              "valueFrom": {
+                                 "secretKeyRef" : {
+                                    "name" : "${APPLICATION_NAME}",
+                                    "key" : "application-password"
+                                 }
+                              }
+                           }
+                        ],
+                        "image": "${IMAGE}",
+                        "livenessProbe": {
+                           "exec": {
+                              "command": [
+                                 "/opt/datagrid/bin/livenessProbe.sh"
+                              ]
+                           },
+                           "initialDelaySeconds": 15,
+                           "timeoutSeconds": 10,
+                           "periodSeconds": 20,
+                           "successThreshold": 1,
+                           "failureThreshold": 5
+                        },
+                        "readinessProbe": {
+                           "exec": {
+                              "command": [
+                                 "/opt/datagrid/bin/readinessProbe.sh"
+                              ]
+                           },
+                           "initialDelaySeconds": 17,
+                           "timeoutSeconds": 10,
+                           "periodSeconds": 20,
+                           "successThreshold": 2,
+                           "failureThreshold": 5
+                        },
+                        "name": "${APPLICATION_NAME}",
+                        "ports": [
+                           {
+                              "containerPort": 8080,
+                              "name": "http",
+                              "protocol": "TCP"
+                           },
+                           {
+                              "containerPort": 8888,
+                              "name": "ping",
+                              "protocol": "TCP"
+                           },
+                           {
+                              "containerPort": 11222,
+                              "name": "hotrod",
+                              "protocol": "TCP"
+                           }
+                        ],
+                        "volumeMounts": [
+                           {
+                              "name": "srv-data",
+                              "mountPath": "/opt/datagrid/standalone/data"
+                           },
+                           {
+                              "name": "keystore-volume",
+                              "mountPath": "/var/run/secrets/java.io/keystores"
+                           },
+                           {
+                              "name": "service-certs",
+                              "mountPath": "/var/run/secrets/openshift.io/serviceaccount"
+                           }
+                        ],
+                        "resources": {
+                           "requests": {
+                              "cpu": "0.5",
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           },
+                           "limits": {
+                              "memory": "${TOTAL_CONTAINER_MEM}Mi"
+                           }
+                        }
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "name": "keystore-volume",
+                        "empty-dir": {}
+                     },
+                     {
+                        "name": "service-certs",
+                        "secret": {
+                           "secretName": "service-certs"
+                        }
+                     }
+                  ],
+                  "terminationGracePeriodSeconds": 60
+               }
+            },
+            "triggers": [
+               {
+                  "type": "ConfigChange"
+               }
+            ],
+            "volumeClaimTemplates": [
+               {
+                  "metadata": {
+                     "name": "srv-data"
+                  },
+                  "spec": {
+                     "accessModes": [
+                        "ReadWriteOnce"
+                     ],
+                     "resources": {
+                        "requests": {
+                           "storage": "1Gi"
+                        }
+                     }
+                  }
+               }
+            ]
+         }
+      }
+   ],
+   "parameters": [
+      {
+         "description": "The name for the application.",
+         "name": "APPLICATION_NAME",
+         "displayName": "Application Name",
+         "required": true,
+         "value": "datagrid-service"
+      },
+      {
+         "description": "Infinispan image.",
+         "name": "IMAGE",
+         "required": true,
+         "value": "registry.access.redhat.com/jboss-datagrid-7/datagrid72-openshift"
+      },
+      {
+         "description": "Number of instances in the cluster.",
+         "name": "NUMBER_OF_INSTANCES",
+         "displayName": "Number of Instances",
+         "required": true,
+         "value": "1"
+      },
+      {
+         "description": "Total container memory in MiB.",
+         "displayName": "Total Memory",
+         "name": "TOTAL_CONTAINER_MEM",
+         "required": false,
+         "value": "512"
+      },
+      {
+         "name": "APPLICATION_USER",
+         "displayName": "Client User",
+         "description": "Username for client applications",
+         "required": true
+      },
+      {
+         "name": "APPLICATION_USER_PASSWORD",
+         "displayName": "Client Password",
+         "description": "Password for client applications",
+         "generate": "expression",
+         "from": "[a-zA-Z0-9]{16}"
+      }
+   ]
+}

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/caching/ScalingTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/caching/ScalingTest.java
@@ -51,7 +51,7 @@ public class ScalingTest {
    @InSequence(1)
    @Test
    public void scale_up() {
-      scalingTester.scaleUpStatefulSet(SERVICE_NAME, client, commandlineClient, readinessCheck);
+      scalingTester.scaleUpStatefulSet(2, SERVICE_NAME, client, commandlineClient, readinessCheck);
    }
 
    @InSequence(2)
@@ -67,6 +67,6 @@ public class ScalingTest {
    @InSequence(3)
    @Test
    public void scale_down() {
-      scalingTester.scaleDownStatefulSet(SERVICE_NAME, client, commandlineClient, readinessCheck);
+      scalingTester.scaleDownStatefulSet(1, SERVICE_NAME, client, commandlineClient, readinessCheck);
    }
 }

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
@@ -1,0 +1,67 @@
+package org.infinispan.online.service.datagrid;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.infinispan.online.service.endpoint.HotRodTester;
+import org.infinispan.online.service.endpoint.RESTTester;
+import org.infinispan.online.service.scaling.ScalingTester;
+import org.infinispan.online.service.utils.DeploymentHelper;
+import org.infinispan.online.service.utils.OpenShiftClientCreator;
+import org.infinispan.online.service.utils.OpenShiftHandle;
+import org.infinispan.online.service.utils.ReadinessCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class DatagridServiceTest {
+
+   private static final String SERVICE_NAME = "datagrid-service";
+
+   private URL restService;
+   private HotRodTester hotRodTester;
+   private OpenShiftClient client = OpenShiftClientCreator.getClient();
+   private RESTTester restTester = new RESTTester(SERVICE_NAME, client);
+
+   private ReadinessCheck readinessCheck = new ReadinessCheck();
+   private OpenShiftHandle handle = new OpenShiftHandle(client);
+
+   @Deployment
+   public static Archive<?> deploymentApp() {
+      return ShrinkWrap
+         .create(WebArchive.class, "test.war")
+         .addAsLibraries(DeploymentHelper.testLibs())
+         .addPackage(DatagridServiceTest.class.getPackage())
+         .addPackage(ReadinessCheck.class.getPackage())
+         .addPackage(ScalingTester.class.getPackage())
+         .addPackage(HotRodTester.class.getPackage());
+   }
+
+   @Before
+   public void before() throws MalformedURLException {
+      readinessCheck.waitUntilAllPodsAreReady(client);
+      restService = handle.getServiceWithName(SERVICE_NAME + "-https");
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      hotRodTester = new HotRodTester(SERVICE_NAME, hotRodService, client);
+   }
+
+   @Test
+   public void should_read_and_write_through_hotrod_endpoint() {
+      hotRodTester.putGetTest();
+   }
+
+   @Test
+   public void should_read_and_write_through_rest_endpoint() {
+      restTester.putGetRemoveTest(restService);
+   }
+
+}

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/PermanentCacheTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/PermanentCacheTest.java
@@ -1,0 +1,94 @@
+package org.infinispan.online.service.datagrid;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.infinispan.online.service.endpoint.HotRodTester;
+import org.infinispan.online.service.scaling.ScalingTester;
+import org.infinispan.online.service.utils.DeploymentHelper;
+import org.infinispan.online.service.utils.OpenShiftClientCreator;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
+import org.infinispan.online.service.utils.OpenShiftHandle;
+import org.infinispan.online.service.utils.ReadinessCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class PermanentCacheTest {
+
+   private static final String SERVICE_NAME = "datagrid-service";
+
+   URL hotRodService;
+   URL restService;
+   OpenShiftClient client = OpenShiftClientCreator.getClient();
+
+   ReadinessCheck readinessCheck = new ReadinessCheck();
+   OpenShiftHandle handle = new OpenShiftHandle(client);
+
+   ScalingTester scalingTester = new ScalingTester();
+   OpenShiftCommandlineClient commandlineClient = new OpenShiftCommandlineClient();
+
+   @Deployment
+   public static Archive<?> deploymentApp() {
+      return ShrinkWrap
+         .create(WebArchive.class, "test.war")
+         .addAsLibraries(DeploymentHelper.testLibs())
+         .addPackage(DatagridServiceTest.class.getPackage())
+         .addPackage(ReadinessCheck.class.getPackage())
+         .addPackage(ScalingTester.class.getPackage())
+         .addPackage(HotRodTester.class.getPackage());
+   }
+
+   @Before
+   public void before() throws MalformedURLException {
+      readinessCheck.waitUntilAllPodsAreReady(client);
+      hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      restService = handle.getServiceWithName(SERVICE_NAME + "-https");
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+   }
+
+   @InSequence(1)
+   @Test
+   public void create_named_cache() throws Exception {
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      HotRodTester hotRodTester = new HotRodTester(SERVICE_NAME, hotRodService, client);
+
+      hotRodTester.createNamedCache("custom", "replicated");
+      hotRodTester.namedCachePutGetTest("custom");
+   }
+
+   @RunAsClient
+   @InSequence(2) //must be run from the client where "oc" is installed
+   @Test
+   public void scale_down() {
+      scalingTester.scaleDownStatefulSet(0, SERVICE_NAME, client, commandlineClient, readinessCheck);
+   }
+
+   @RunAsClient
+   @InSequence(3) //must be run from the client where "oc" is installed
+   @Test
+   public void scale_up() {
+      scalingTester.scaleUpStatefulSet(1, SERVICE_NAME, client, commandlineClient, readinessCheck);
+   }
+
+   @InSequence(4)
+   @Test
+   public void use_named_cache() throws Exception {
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      HotRodTester hotRodTester = new HotRodTester(SERVICE_NAME, hotRodService, client);
+
+      hotRodTester.namedCachePutGetTest("custom");
+   }
+
+}

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
@@ -18,6 +18,7 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.SaslQop;
 import org.infinispan.client.hotrod.impl.RemoteCacheImpl;
+import org.infinispan.commons.api.CacheContainerAdmin;
 import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.online.service.utils.TrustStore;
 
@@ -201,4 +202,20 @@ public class HotRodTester implements EndpointTester {
          currentCacheSize = byteArrayCache.size();
       } while (currentCacheSize > lastCacheSize);
    }
+
+   public void createNamedCache(String cacheName, String template) {
+      cacheManager.administration()
+         .withFlags(CacheContainerAdmin.AdminFlag.PERMANENT)
+         .createCache(cacheName, template);
+   }
+
+   public void namedCachePutGetTest(String cacheName) {
+      //given
+      RemoteCache<String, String> stringCache = cacheManager.getCache(cacheName);
+      //when
+      stringCache.put(hotRodKey, "value");
+      //then
+      assertEquals("value", stringCache.get(hotRodKey));
+   }
+
 }

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
@@ -9,9 +9,9 @@ import io.fabric8.openshift.client.OpenShiftClient;
 
 public class ScalingTester {
 
-   public void scaleUpStatefulSet(String statefulSetName, OpenShiftClient client, OpenShiftCommandlineClient commandlineClient, ReadinessCheck readinessCheck) {
-      commandlineClient.scaleStatefulSet(statefulSetName, 2);
-      readinessCheck.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, 2, client);
+   public void scaleUpStatefulSet(int numReplicas, String statefulSetName, OpenShiftClient client, OpenShiftCommandlineClient commandlineClient, ReadinessCheck readinessCheck) {
+      commandlineClient.scaleStatefulSet(statefulSetName, numReplicas);
+      readinessCheck.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, numReplicas, client);
    }
 
    public void waitForClusterToForm(HotRodTester hotRodTester) {
@@ -22,8 +22,8 @@ public class ScalingTester {
       waiter.waitFor(() -> hotRodTester.getNumberOfNodesInTheCluster() == 2);
    }
 
-   public void scaleDownStatefulSet(String statefulSetName, OpenShiftClient client, OpenShiftCommandlineClient commandlineClient, ReadinessCheck readinessCheck) {
-      commandlineClient.scaleStatefulSet(statefulSetName, 1);
+   public void scaleDownStatefulSet(int numReplicas, String statefulSetName, OpenShiftClient client, OpenShiftCommandlineClient commandlineClient, ReadinessCheck readinessCheck) {
+      commandlineClient.scaleStatefulSet(statefulSetName, numReplicas);
       readinessCheck.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, 1, client);
    }
 }

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/utils/TrustStore.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/utils/TrustStore.java
@@ -33,7 +33,7 @@ public class TrustStore {
    public String getPath() {
       Path currentRelativePath = Paths.get(trustStoreDir);
       String absolutePath = currentRelativePath.toAbsolutePath().toString();
-      return String.format("%s/%s.p12", absolutePath, serviceName);
+      return String.format("%s/truststore.p12", absolutePath);
    }
 
    private void create() {

--- a/services/functional-tests/src/test/resources/arquillian.xml
+++ b/services/functional-tests/src/test/resources/arquillian.xml
@@ -30,7 +30,7 @@
            Note: The EAP pod has to have DEBUG=true in the json definition so that EAP start in debug mode
         -->
         <property name="definitionsFile">target/classes/eap7-testrunner.json</property>
-        <property name="wait.for.service.list">caching-service-hotrod, caching-service-https</property>
+        <property name="wait.for.service.list">caching-service-hotrod, caching-service-https, datagrid-service-hotrod, datagrid-service-https</property>
         <property name="env.script.env">image=${image}</property>
         <property name="proxiedContainerPorts">testrunner:9990</property>
         <!-- Fetch the logs from Openshift and pods, and save them into target/surefire-reports -->

--- a/services/functional-tests/src/test/resources/destroy.sh
+++ b/services/functional-tests/src/test/resources/destroy.sh
@@ -21,7 +21,9 @@ oc logs testrunner
 
 echo "---- Clearing up test resources ---"
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=caching-service || true
+oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=datagrid-service || true
 oc delete template caching-service || true
+oc delete template datagrid-service || true
 oc delete service testrunner || true
 oc delete route testrunner || true
 

--- a/services/functional-tests/src/test/resources/eap7-testrunner.json
+++ b/services/functional-tests/src/test/resources/eap7-testrunner.json
@@ -82,7 +82,7 @@
           },
           {
             "name": "TRUSTSTORE_FILE",
-            "value": "/var/run/secrets/java.io/keystores/caching-service.p12"
+            "value": "/var/run/secrets/java.io/keystores/truststore.p12"
           },
           {
             "name": "TRUSTSTORE_PASSWORD",

--- a/services/functional-tests/src/test/resources/setup.sh
+++ b/services/functional-tests/src/test/resources/setup.sh
@@ -5,7 +5,9 @@ IMAGE_NAME=${image:-jboss-datagrid-7/datagrid72-openshift}
 
 echo "---- Clearing up (any potential) leftovers ----"
 oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=caching-service || true
+oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles,rolebindings,serviceaccounts --selector=template=datagrid-service || true
 oc delete template caching-service || true
+oc delete template datagrid-service || true
 
 echo "---- Creating Caching Service for test ----"
 echo "Current dir $PWD"
@@ -14,3 +16,11 @@ echo "Using image $IMAGE_NAME"
 oc create -f ../caching-service.json
 
 oc process caching-service -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -
+
+echo "---- Creating Datagrid Service for test ----"
+echo "Current dir $PWD"
+echo "Using image $IMAGE_NAME"
+
+oc create -f ../datagrid-service.json
+
+oc process datagrid-service -p IMAGE=${IMAGE_NAME} -p APPLICATION_USER=test -p APPLICATION_USER_PASSWORD=test | oc create -f -


### PR DESCRIPTION
Builds on @ryanemerson's changes in #85 to add the datagrid service template.

This template is designed to be non-ephemeral, so for any cache definitions created at runtime must be persisted and must survive. This template achieves this by using volume mounts on top of stateful sets and configuring Infinispan's global state to be stored in overlay.

I've tried to add a test that verifies this but some of the test dependencies do not seem to be productized. When using purely product repositories (e.g. using [JDG's maven settings](https://github.com/infinispan/jdg/blob/jdg-7.2.x/maven-settings.xml)) I get:

```
[ERROR] Failed to execute goal on project datagrid-online-services-functional-tests: 
Could not resolve dependencies for project org.infinispan:datagrid-online-services-functional-tests:jar:1.0.0-SNAPSHOT: The following artifacts could not be resolved: io.fabric8:openshift-client:jar:3.0.3, org.arquillian.cube:arquillian-cube-openshift:jar:1.10.0, org.arquillian.cube:arquillian-cube-requirement:jar:1.10.0, org.assertj:assertj-core:jar:3.8.0, org.eclipse.jetty:jetty-client:jar:9.4.8.v20171121, org.arquillian.container:arquillian-container-chameleon:jar:1.0.0.Beta2: Could not find artifact io.fabric8:openshift-client:jar:3.0.3 in mead-jdg7 (http://download.eng.bos.redhat.com/brewroot/repos/jb-dg-7-rhel-7-build/latest/maven/)
``` 

The test I'm trying to reproduce is this:

* Create a cache.
* Do a Hot Rod put/get on that cache.
* Scale stateful set to 0 replicas.
* Scale stateful set to 1 replicas.
* Do a Hot Rod put/get on that cache.