### PR TITLE
Adds back Data Grid 6.5 templates b/c OpenShift Library

### DIFF
--- a/templates/deprecated/datagrid65-image-stream.json
+++ b/templates/deprecated/datagrid65-image-stream.json
@@ -1,0 +1,175 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "datagrid65-image-streams",
+        "annotations": {
+            "description": "ImageStream definitions for Red Hat JBoss Data Grid 6.5.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jboss-datagrid65-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.16"
+                }
+            },
+            "labels": {
+                "xpaas": "1.4.16"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.2",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:6.5",
+                            "version": "1.2",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.2"
+                        }
+                    },
+                    {
+                        "name": "1.3",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:6.5",
+                            "version": "1.3",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.3"
+                        }
+                    },
+                    {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:6.5",
+                            "version": "1.4",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.4"
+                        }
+                    },
+                    {
+                        "name": "1.5",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:6.5",
+                            "version": "1.5",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.5"
+                        }
+                    },
+                    {
+                        "name": "1.6",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 S2I images.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:6.5",
+                            "version": "1.6",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-openshift:1.6"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "jboss-datagrid65-client-openshift",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "1.4.16"
+                }
+            },
+            "labels": {
+                "xpaas": "1.4.16"
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.0",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "client,jboss,hidden",
+                            "version": "1.0",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.0"
+                        }
+                    },
+                    {
+                        "name": "1.1",
+                        "annotations": {
+                            "description": "JBoss Data Grid 6.5 Client Modules for EAP.",
+                            "iconClass": "icon-datagrid",
+                            "tags": "client,jboss,hidden",
+                            "version": "1.1",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 6.5 Client Modules for EAP"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-6/datagrid65-client-openshift:1.1"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Necessary for using the new Terms Based Registry (registry.redhat.io).

We should not ever remove imagestreamtags because customers may have deployed
content referencing those. If they are removed, the deployment content becomes
broken, as it will potentially be referencing a non-existent imagestreamtag.
Whether the image backing the imagestreamtag is EOL/Deprecated or not is irrelevant.

Used version `1.4.16` to sync with [`application-templates`](https://github.com/jboss-openshift/application-templates).

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

~- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`~
~- [ ] Pull Request contains link to the JIRA issue~
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
