### PR TITLE
Custom Server Configuration

### DIFF
--- a/docs/datagrid72-user-xml.adoc
+++ b/docs/datagrid72-user-xml.adoc
@@ -1,0 +1,37 @@
+== Custom User Standalone XML Configuration
+= Usage
+
+To provide custom configurations you must:
+1. Create a config map containing at least `standalone.xml` which is mounted at `/opt/datagrid/standalone/configuration/user`
+2. Set the environment variable `USER_CONFIG_MAP=true` in your template
+3. Expose the required services and ports in your template
+
+When `USER_CONFIG_MAP=true` our image copies the contents of `opt/datagrid/standalone/configuration/user`. i.e. the configmap, to `/opt/datagrid/standalone/configuration`.
+This means that in addition to passing `standalone.xml`, it is also possible to provide `logging.properties`, `application-role.properties` etc in the configmap.
+
+Creating a configmap containing the desired configuration files is trivial, as an entire directory can be used to create a configmap consisting of filenames and their contents as key/values in the configmap. This can be achieved via `oc create configmap <name-of-configmap> --from-file=<local-dir>`.
+
+To create an application that uses a custom configuration, login to your openshift cluster via `oc`, push your built image to the cluster's repository and execute the following:
+
+1. `oc create -f templates/datagrid72-user-xml.json`
+2. `oc create configmap datagrid-config --from-file=docs/examples/user-configuration`
+3. `oc new-app user-xml`
+
+The server should then startup with the provided configuration files.
+
+= Example Template
+`templates/datagrid72-user-xml.json` is a basic template that shows how a config map can be created and the `USER_CONFIG_MAP` should be set.
+Furthermore, this template exposes the ports required for the ping, hotrod and rest protocols.
+
+NOTE: If using openshift.DNS_PING protocol for JGroups discovery (recommended) it's also necessary to set the ENV variable `OPENSHIFT_DNS_PING_SERVICE_NAME` to the name of the ping service
+and `OPENSHIFT_DNS_PING_SERVICE_PORT` to the exposed port.
+
+= Image Env Variables
+In the provided link:examples/user-configuration/standalone.xml[standalone.xml] we have included several comments beginning and ending with `##`, e.g. `<!-- ##JGROUPS_ENCRYPT## -->`.
+If you keep these comments in your `standalone.xml` file, then it remains possible to use some of the images environment variables
+for more complicated tasks such as enabling encryption in JGroups. Environment variables related infinispan caches
+and endpoints no longer work when providing a configuration via a configmap, therefore all cache/endpoint configuration
+has to occur in your `standalone.xml` file.
+
+NOTE: It is possible to remove the aforementioned xml comments, however it will result in certain environment variables
+being ignored.

--- a/docs/examples/user-configuration/standalone.xml
+++ b/docs/examples/user-configuration/standalone.xml
@@ -1,0 +1,325 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:4.0">
+    <extensions>
+        <extension module="org.infinispan.extension"/>
+        <extension module="org.infinispan.server.endpoint"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jgroups.extension"/>
+        <extension module="org.wildfly.extension.io"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true"/>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization map-groups-to-roles="false">
+                    <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                </authorization>
+                <!-- ##SERVER_IDENTITIES## -->
+            </security-realm>
+            <!-- ##DATAGRID_REALM## -->
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir"
+                              path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="false" enabled="false">
+                <handlers>
+                    <handler name="file"/>
+                </handlers>
+            </logger>
+        </audit-log>
+        <management-interfaces>
+            <http-interface http-upgrade-enabled="true" console-enabled="false"><!-- ##MGMT_IFACE_REALM## -->
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:3.0">
+            <console-handler name="CONSOLE">
+                <formatter>
+                    <named-formatter name="COLOR-PATTERN"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <size-rotating-file-handler name="HR-ACCESS-FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="ACCESS-LOG"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="hotrod-access.log"/>
+                <append value="true"/>
+                <rotate-size value="10M"/>
+                <max-backup-index value="10"/>
+            </size-rotating-file-handler>
+            <size-rotating-file-handler name="REST-ACCESS-FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="ACCESS-LOG"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="rest-access.log"/>
+                <append value="true"/>
+                <rotate-size value="10M"/>
+                <max-backup-index value="10"/>
+            </size-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.jboss.as.config">
+                <level name="DEBUG"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.infinispan.HOTROD_ACCESS_LOG" use-parent-handlers="false">
+                <!-- Set to TRACE to enable access logging for hot rod or use DMR -->
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="HR-ACCESS-FILE"/>
+                </handlers>
+            </logger>
+            <!-- ##ACCESS_LOG_HANDLER## -->
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                </handlers>
+            </root-logger>
+            <formatter name="OPENSHIFT">
+                <custom-formatter module="org.jboss.logmanager.ext"
+                                  class="org.jboss.logmanager.ext.formatters.LogstashFormatter">
+                    <properties>
+                        <property name="metaData" value="log-handler=CONSOLE"/>
+                    </properties>
+                </custom-formatter>
+            </formatter>
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            </formatter>
+            <formatter name="ACCESS-LOG">
+                <pattern-formatter
+                        pattern="%X{address} %X{user} [%d{dd/MMM/yyyy:HH:mm:ss z}] &quot;%X{method} %m %X{protocol}&quot; %X{status} %X{requestSize} %X{responseSize} %X{duration}%n"/>
+            </formatter>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"
+                                runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:datasources:4.0">
+            <datasources>
+                <!-- ##DATASOURCES## -->
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                    <driver name="mysql" module="com.mysql">
+                        <xa-datasource-class>com.mysql.jdbc.jdbc2.optional.MysqlXADataSource</xa-datasource-class>
+                    </driver>
+                    <driver name="postgresql" module="org.postgresql">
+                        <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
+                    </driver>
+                    <!-- ##DRIVERS## -->
+                </drivers>
+            </datasources>
+        </subsystem>
+        <!-- Configure Infinispan Endpoints -->
+        <subsystem xmlns="urn:infinispan:server:endpoint:8.1">
+            <hotrod-connector cache-container="clustered" socket-binding="hotrod" name="hotrod"/>
+            <rest-connector name="rest" socket-binding="rest" cache-container="clustered"/>
+        </subsystem>
+        <!-- Configure Infinispan Caches -->
+        <subsystem xmlns="urn:infinispan:server:core:8.5" default-cache-container="clustered">
+            <cache-container name="clustered" default-cache="default">
+                <transport channel="cluster"/>
+                <global-state/>
+                <distributed-cache name="default" mode="SYNC"/>
+            </cache-container>
+        </subsystem>
+        <!-- Configure Infinispan's JGroups Stack -->
+        <subsystem xmlns="urn:infinispan:server:jgroups:8.0">
+            <channels default="cluster">
+                <channel name="cluster" stack="tcp"/>
+            </channels>
+            <stacks>
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="openshift.DNS_PING" socket-binding="jgroups-mping"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <!-- ##JGROUPS_ENCRYPT## -->
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <!-- ##JGROUPS_AUTH## -->
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG3"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="openshift.DNS_PING" socket-binding="jgroups-mping"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <!-- ##JGROUPS_ENCRYPT## -->
+                    <protocol type="pbcast.NAKACK2">
+                        <property name="use_mcast_xmit">false</property>
+                    </protocol>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <!-- ##JGROUPS_AUTH## -->
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG3"/>
+                </stack>
+            </stacks>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:io:1.1">
+            <worker name="default"/>
+            <buffer-pool name="default"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jca:4.0">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <remote-naming/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+            <endpoint/>
+            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:security:1.2">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jaspitest" cache-type="default">
+                    <authentication-jaspi>
+                        <login-module-stack name="dummy">
+                            <login-module code="Dummy" flag="optional"/>
+                        </login-module-stack>
+                        <auth-module code="Dummy"/>
+                    </authentication-jaspi>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:transactions:3.0">
+            <core-environment node-identifier="${jboss.node.name}">
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"
+                                  recovery-listener="true"/>
+            <coordinator-environment default-timeout="300"/>
+        </subsystem>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public"
+                          port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="hotrod" port="11222"/>
+        <socket-binding name="jgroups-mping" port="0"
+                        multicast-address="${jboss.default.multicast.address:234.99.54.14}" multicast-port="45700"/>
+        <socket-binding name="jgroups-tcp" port="7600"/>
+        <socket-binding name="jgroups-tcp-fd" port="57600"/>
+        <socket-binding name="jgroups-udp" port="55200"
+                        multicast-address="${jboss.default.multicast.address:234.99.54.14}" multicast-port="45688"/>
+        <socket-binding name="jgroups-udp-fd" port="54200"/>
+        <socket-binding name="rest" port="8080"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+    </socket-binding-group>
+</server>

--- a/modules/datagrid/72/launch/added/launch/openshift-common.sh
+++ b/modules/datagrid/72/launch/added/launch/openshift-common.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
-    set -x
-    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+  set -x
+  echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
 fi
 
-CONFIG_FILE=$JBOSS_HOME/standalone/configuration/clustered-openshift.xml
 LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
+if [ "${USER_CONFIG_MAP^^}" != "TRUE" ]; then
+  CONFIG_FILE=$JBOSS_HOME/standalone/configuration/clustered-openshift.xml
 
-CONFIGURE_SCRIPTS=(
+  CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/backward-compatibility.sh
   $JBOSS_HOME/bin/launch/configure_extensions.sh
   $JBOSS_HOME/bin/launch/passwd.sh
@@ -26,4 +27,25 @@ CONFIGURE_SCRIPTS=(
   $JBOSS_HOME/bin/launch/management-realm.sh
   $JBOSS_HOME/bin/launch/access_log_valve.sh
   /opt/run-java/proxy-options
-)
+  )
+else
+  CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone.xml
+
+  CONFIGURE_SCRIPTS=(
+  $JBOSS_HOME/bin/launch/backward-compatibility.sh
+  $JBOSS_HOME/bin/launch/configure_extensions.sh
+  $JBOSS_HOME/bin/launch/passwd.sh
+  $JBOSS_HOME/bin/launch/authentication-config.sh
+  $JBOSS_HOME/bin/launch/datasource.sh
+  $JBOSS_HOME/bin/launch/admin.sh
+  $JBOSS_HOME/bin/launch/ha.sh
+  $JBOSS_HOME/bin/launch/jgroups.sh
+  $JBOSS_HOME/bin/launch/https.sh
+  $JBOSS_HOME/bin/launch/json_logging.sh
+  $JBOSS_HOME/bin/launch/security-domains.sh
+  $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
+  $JBOSS_HOME/bin/launch/management-realm.sh
+  $JBOSS_HOME/bin/launch/access_log_valve.sh
+  /opt/run-java/proxy-options
+  )
+fi

--- a/modules/datagrid/72/launch/added/openshift-launch.sh
+++ b/modules/datagrid/72/launch/added/openshift-launch.sh
@@ -23,10 +23,25 @@ function init_data_dir() {
   fi
 }
 
+function copy_user_files() {
+  local config_dir=${JBOSS_HOME}/standalone/configuration
+  # Remove default standalone.xml so that an error is thrown if the user does not pass a standalone.xml file in the configmap
+  rm $config_dir/standalone.xml
+  cp $config_dir/user/* $config_dir
+}
+
 SPLIT_DATA=${SPLIT_DATA:-$DATAGRID_SPLIT}
 SPLIT_LOCK_TIMEOUT=${SPLIT_LOCK_TIMEOUT:-$DATAGRID_LOCK_TIMEOUT}
 
-if [ "${SPLIT_DATA^^}" = "TRUE" ]; then
+# If USER_CONFIG_MAP is true, then we launch the server using the standalone.xml provided by the user in a configmap
+if [ "${USER_CONFIG_MAP^^}" = "TRUE" ]; then
+  copy_user_files
+
+  log_info "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION with user standalone.xml"
+  source $JBOSS_HOME/bin/launch/configure.sh
+  exec $JBOSS_HOME/bin/standalone.sh -bmanagement 127.0.0.1 ${JBOSS_HA_ARGS} ${JAVA_PROXY_OPTIONS}
+
+elif [ "${SPLIT_DATA^^}" = "TRUE" ]; then
   source /opt/partition/partitionPV.sh
 
   DATA_DIR="${JBOSS_HOME}/standalone/partitioned_data"

--- a/templates/datagrid72-user-xml.json
+++ b/templates/datagrid72-user-xml.json
@@ -1,0 +1,230 @@
+{
+    "kind": "Template",
+    "apiVersion": "v1",
+    "metadata": {
+        "annotations": {
+            "iconClass": "icon-datagrid",
+            "tags": "datagrid,jboss",
+            "version": "1.2",
+            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.2 (User Config)",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
+            "template.openshift.io/long-description": "This template defines resources needed to develop Red Hat JBoss Data Grid 7.2 based applications, including a deployment configuration, using ephemeral (temporary) storage and communication using http.",
+            "template.openshift.io/documentation-url": "https://access.redhat.com/documentation/en/red-hat-jboss-data-grid/",
+            "template.openshift.io/support-url": "https://access.redhat.com"
+        },
+        "name": "user-xml"
+    },
+    "labels": {
+        "template": "user-xml"
+    },
+    "message": "A new data grid service has been created in your project.",
+    "parameters": [
+        {
+            "displayName": "Application Name",
+            "description": "The name for the application.",
+            "name": "APPLICATION_NAME",
+            "value": "datagrid-app",
+            "required": true
+        },
+        {
+            "description": "Infinispan image.",
+            "name": "IMAGE",
+            "required": true,
+            "value": "registry.redhat.io/jboss-datagrid-7/datagrid72-openshift"
+        }
+    ],
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "The web server's HTTP port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-http"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 8080,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "description": "Hot Rod's port."
+                },
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "name": "${APPLICATION_NAME}-hotrod"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "port": 11222,
+                        "targetPort": 11222
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "spec": {
+                "clusterIP": "None",
+                "ports": [
+                    {
+                        "name": "ping",
+                        "port": 8888
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                }
+            },
+            "metadata": {
+                "name": "${APPLICATION_NAME}-ping",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                },
+                "annotations": {
+                    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+                    "description": "The JGroups ping port for clustering."
+                }
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "terminationGracePeriodSeconds": 60,
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}",
+                                "image": "${IMAGE}",
+                                "imagePullPolicy": "Always",
+                                "resources": {
+                                    "limits": {
+                                        "memory": "1Gi"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "config-volume",
+                                        "mountPath": "/opt/datagrid/standalone/configuration/user",
+                                        "readOnly": true
+                                    }
+                                ],
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/datagrid/bin/livenessProbe.sh"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 60
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/datagrid/bin/readinessProbe.sh"
+                                        ]
+                                    }
+                                },
+                                "ports": [
+                                    {
+                                        "containerPort": 8080,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 8888,
+                                        "name": "ping",
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 11222,
+                                        "name": "hotrod",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "USER_CONFIG_MAP",
+                                        "value": "true"
+                                    },
+                                    {
+                                        "name": "JGROUPS_PING_PROTOCOL",
+                                        "value": "openshift.DNS_PING"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
+                                        "value": "${APPLICATION_NAME}-ping"
+                                    },
+                                    {
+                                        "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+                                        "value": "8888"
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "config-volume",
+                                "configMap": {
+                                    "name": "datagrid-config"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This is a POC that allows for a user to provide any of the server configuration files via a configmap.

To provide custom configurations the user must:
1. Create a config map containing at least `standalone.xml` which is stored at `/opt/datagrid/standalone/configuration/user`
2. Set the environment variable `USER_CONFIG_MAP=true` in their template

When `USER_CONFIG_MAP=true` our image foregoes executing any of the usual configuration scrips and instead copies the contents of `opt/datagrid/standalone/configuration/user`. i.e. the configmap, to `/opt/datagrid/standalone/configuration`. This means that in addition to passing `standalone.xml`, it is also possible for users to provide `logging.properties`, `application-role.properties` etc in their configmap.

Creating a configmap containing the desired configuration files is trivial, as an entire directory can be used to create a configmap consisting of filenames and their contents as key/values in the configmap. This is achieve via `oc create configmap <name-of-configmap> --from-file=<local-dir>`

To test this PR locally execute the following:

1. `make start-openshift-with-catalog login-to-openshift prepare-openshift-project build-image push-image-to-local-openshift`
2. `oc create -f templates/datagrid72-user-xml.json`
3. `oc create configmap datagrid-config --from-file=<config_dir or just standalone.xml>`
4. `oc new-app custom-xml -p IMAGE=datagrid72-openshift`

The server should then startup with the provided configuration files. Obviously from a user perspective, only steps 2-4 would be necessary. Also note, that `datagrid72-user-xml.json` is a very basic template to show how configmaps work. In reality the user would have to define services and ports to expose any configured endpoints as we do in other templates.