### PR TITLE
JDG-2159 Data survives with file cache store in datagrid service

### DIFF
--- a/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/PersistedDataSurvivesTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/PersistedDataSurvivesTest.java
@@ -1,0 +1,107 @@
+package org.infinispan.online.service.datagrid;
+
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.infinispan.commons.configuration.XMLStringConfiguration;
+import org.infinispan.online.service.endpoint.HotRodTester;
+import org.infinispan.online.service.scaling.ScalingTester;
+import org.infinispan.online.service.utils.DeploymentHelper;
+import org.infinispan.online.service.utils.OpenShiftClientCreator;
+import org.infinispan.online.service.utils.OpenShiftCommandlineClient;
+import org.infinispan.online.service.utils.OpenShiftHandle;
+import org.infinispan.online.service.utils.ReadinessCheck;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class PersistedDataSurvivesTest {
+
+   private static final String SERVICE_NAME = "datagrid-service";
+   private static final String CACHE_NAME = "custom-persistent";
+
+   private OpenShiftClient client = OpenShiftClientCreator.getClient();
+
+   private ReadinessCheck readinessCheck = new ReadinessCheck();
+   private OpenShiftHandle handle = new OpenShiftHandle(client);
+
+   private ScalingTester scalingTester = new ScalingTester();
+   private OpenShiftCommandlineClient commandlineClient = new OpenShiftCommandlineClient();
+
+   @Deployment
+   public static Archive<?> deploymentApp() {
+      return ShrinkWrap
+         .create(WebArchive.class, "test.war")
+         .addAsLibraries(DeploymentHelper.testLibs())
+         .addPackage(ReadinessCheck.class.getPackage())
+         .addPackage(ScalingTester.class.getPackage())
+         .addPackage(HotRodTester.class.getPackage());
+   }
+
+   @Before
+   public void before() {
+      readinessCheck.waitUntilAllPodsAreReady(client);
+   }
+
+   @InSequence(1)
+   @Test
+   public void put_on_persisted_cache() throws Exception {
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      HotRodTester hotRodTester = new HotRodTester(SERVICE_NAME, hotRodService, client);
+
+      String cacheCfg = String.format(
+         "<infinispan>" +
+            "<cache-container>" +
+               "<distributed-cache name=\"%1$s\">" +
+                  "<persistence passivation=\"false\">" +
+                     "<file-store " +
+                        "shared=\"false\" " +
+                        "fetch-state=\"true\" " +
+                        "path=\"${jboss.server.data.dir}/datagrid-infinispan/%1$s\"" +
+                     "/>" +
+                  "</persistence>" +
+               "</distributed-cache>" +
+            "</cache-container>" +
+         "</infinispan>",
+         CACHE_NAME
+      );
+
+      hotRodTester.createNamedCache("custom-persistent", new XMLStringConfiguration(cacheCfg));
+      hotRodTester.namedCachePutGetTest("custom-persistent");
+   }
+
+   @RunAsClient
+   @InSequence(2) //must be run from the client where "oc" is installed
+   @Test
+   public void scale_down() {
+      scalingTester.scaleDownStatefulSet(0, SERVICE_NAME, client, commandlineClient, readinessCheck);
+   }
+
+   @RunAsClient
+   @InSequence(3) //must be run from the client where "oc" is installed
+   @Test
+   public void scale_up() {
+      scalingTester.scaleUpStatefulSet(1, SERVICE_NAME, client, commandlineClient, readinessCheck);
+   }
+
+   @InSequence(4)
+   @Test
+   public void get_on_persisted_cache() throws Exception {
+      URL hotRodService = handle.getServiceWithName(SERVICE_NAME + "-hotrod");
+      HotRodTester hotRodTester = new HotRodTester(SERVICE_NAME, hotRodService, client);
+
+      hotRodTester.namedCacheGetTest("custom-persistent");
+   }
+
+}

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodTester.java
@@ -19,6 +19,7 @@ import org.infinispan.client.hotrod.configuration.SaslQop;
 import org.infinispan.client.hotrod.configuration.SslConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.commons.api.CacheContainerAdmin;
+import org.infinispan.commons.configuration.BasicConfiguration;
 import org.infinispan.online.service.utils.TrustStore;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -212,11 +213,24 @@ public class HotRodTester implements EndpointTester {
          .createCache(cacheName, template);
    }
 
+   public void createNamedCache(String cacheName, BasicConfiguration cacheCfg) {
+      cacheManager.administration()
+         .withFlags(CacheContainerAdmin.AdminFlag.PERMANENT)
+         .createCache(cacheName, cacheCfg);
+   }
+
    public void namedCachePutGetTest(String cacheName) {
       //given
       RemoteCache<String, String> stringCache = cacheManager.getCache(cacheName);
       //when
       stringCache.put(hotRodKey, "value");
+      //then
+      assertEquals("value", stringCache.get(hotRodKey));
+   }
+
+   public void namedCacheGetTest(String cacheName) {
+      //given
+      RemoteCache<String, String> stringCache = cacheManager.getCache(cacheName);
       //then
       assertEquals("value", stringCache.get(hotRodKey));
    }


### PR DESCRIPTION
* Added test to verify it works with user defined cache xml.
* The user has to make sure file store path is under PV control.
* Server's data folder is under PV control,
  so make sure the file store path is relative to that.
* Necessary because caches created programmatically are different to
  server ones.
* For caches or cache configurations pre-defined in server,
  server integration code makes sure certain defaults are applied.
* Without these defaults, the user has to provide them themselves.