### PR TITLE
JDG-2290 Test that datagrid service can create caches from default

### DIFF
--- a/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
@@ -63,6 +63,20 @@ public class DatagridServiceTest {
    }
 
    @Test
+   public void should_read_and_write_created_caches_from_default_cache() {
+      String cacheName = "sample-datagrid-service-cache";
+
+      try (LazyRemoteCacheManager lazyRemote = HotRodUtil.lazyRemoteCacheManager()) {
+         lazyRemote
+            .andThen(HotRodTester.createCache("default", cacheName))
+            .andThen(remote -> remote.getCache(cacheName))
+            .andThen(HotRodTester.putOnCache())
+            .andThen(HotRodTester.getFromCache())
+            .apply(HotRodConfiguration.secured().apply(SERVICE_NAME));
+      }
+   }
+
+   @Test
    public void should_read_and_write_through_rest_endpoint() {
       restTester.putGetRemoveTest(restService);
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/JDG-2290