### PR TITLE
Necessary changes for using cekit 2.2.1

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -1,0 +1,5 @@
+platforms:
+  only:
+    - x86_64
+compose:
+  pulp_repos: true

--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,3 @@
+x86_64:
+  - rhel-server-rhscl-7-rpms
+  - rhel-7-server-rpms

--- a/image.yaml
+++ b/image.yaml
@@ -202,9 +202,7 @@ modules:
           - name: os-logging
           - name: datagrid.launch
 packages:
-      repositories:
-          - jboss-os
-          - jboss-rhscl
+      content_sets_file: content_sets.yml
       install:
           - rh-mongodb32-mongo-java-driver
           - postgresql-jdbc
@@ -227,6 +225,8 @@ run:
       cmd:
           - "/opt/datagrid/bin/openshift-launch.sh"
 osbs:
+      configuration:
+            container_file: container.yaml
       repository:
             name: containers/jboss-datagrid-7
             branch: jb-datagrid-7.2-openshift-rhel-7


### PR DESCRIPTION
- Dropped support for plain repos
- Changed from plain repos to content_sets file
- Added container.yaml configuration for building in OSBS

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>
