### PR TITLE
CLOUD-2970 Move base layer of image from jboss-openjdk to rhel7

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-datagrid-7/datagrid72-openshift"
 description: "Red Hat JBoss Data Grid 7.2 for OpenShift container image"
 version: "1.3"
-from: "jboss/openjdk18-rhel7:1.1"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-datagrid-7-datagrid72-openshift-container"
@@ -176,6 +176,9 @@ modules:
           - name: datagrid.72.modules
             path: modules/datagrid/72
       install:
+          - name: jboss.container.user
+          - name: jboss.container.openjdk.jdk
+            version: "8"
           - name: distribution
           - name: dynamic-resources
           - name: s2i-common


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2970

@osnipso Creating this PR for 7.3 so it doesn't hold us back for release. 7.2 will still need doing (I assume).