### PR TITLE
[JDG-2062] - Export Data Grid stats to Prometheus

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -50,6 +50,12 @@ envs:
     value: "org.jboss.logmanager,jdk.nashorn.api"
   - name: "DEFAULT_ADMIN_USERNAME"
     value: "jdgadmin"
+  - name: "AB_PROMETHEUS_ENABLE"
+    value: "true"
+    description: "Enable the use of the Prometheus agent"
+  - name: "AB_PROMETHEUS_JMX_EXPORTER_PORT"
+    value: "9779"
+    description: "Port to use for the Prometheus agent" 
   - name: "JAVA_OPTS_APPEND"
     example: "-Dfoo=bar"
     description: "Server startup options."
@@ -166,6 +172,7 @@ ports:
   - value: 8080
   - value: 8443
   - value: 8787
+  - value: 9779 
     expose: false
   - value: 11211
   - value: 11222

--- a/modules/datagrid/launch/added/launch/prometheus.conf
+++ b/modules/datagrid/launch/added/launch/prometheus.conf
@@ -1,0 +1,27 @@
+#
+# ==============================================================================
+# Configure JVM options for Prometheus Agent
+#
+# Env Vars respected:
+#
+# AB_PROMETHEUS_ENABLE: Enable the use of the Prometheus agent.
+#
+# AB_PROMETHEUS_JMX_EXPORTER_PORT: Port to use for the Prometheus JMX Exporter.
+#   Defaults to 9779
+#
+. $JBOSS_HOME/bin/launch/files.sh
+
+# Prometheus agent JAR path in our image
+PROMETHEUS_JAR=$(getfiles io/prometheus/jmx/jdg-7.3/)
+
+# Create a symlink to PROMETHEUS_JAR so it could be referenced easily in case JAVA_OPTS_APPEND env is used to turn on Prometheus
+ln -s ${PROMETHEUS_JAR} ${JBOSS_HOME}/jmx_prometheus_javaagent.jar
+
+AB_PROMETHEUS_JMX_EXPORTER_PORT=$((${AB_PROMETHEUS_JMX_EXPORTER_PORT} + ${PORT_OFFSET:-0}))
+export AB_PROMETHEUS_JMX_EXPORTER_PORT
+
+# add Prometheus options
+if [ "${AB_PROMETHEUS_ENABLE^^}" = "TRUE" ]; then
+  JAVA_OPTS="${JAVA_OPTS} -javaagent:${PROMETHEUS_JAR}=${AB_PROMETHEUS_JMX_EXPORTER_PORT}:${JBOSS_HOME}/bin/prometheus_config.yaml"
+fi
+

--- a/modules/datagrid/launch/configure.sh
+++ b/modules/datagrid/launch/configure.sh
@@ -26,3 +26,6 @@ cp ${ADDED_DIR}/launch/management-realm.sh $JBOSS_HOME/bin/launch
 cp -p ${ADDED_DIR}/launch/adjust_memory.sh $JBOSS_HOME/bin/launch
 cp -p ${ADDED_DIR}/launch/infinispan_service_profiles.sh $JBOSS_HOME/bin/launch
 cp -p ${ADDED_DIR}/launch/service-memory.conf $JBOSS_HOME/bin/launch
+
+# Append Prometheus agent to standalone.conf
+cat ${ADDED_DIR}/launch/prometheus.conf >> $JBOSS_HOME/bin/standalone.conf


### PR DESCRIPTION
Initial implementation of JDG-2062. All DG stats currently available through JMX are to be exported to Prometheus. Needs a rebase.
