### PR TITLE
JDG-2062 Export Data Grid stats to Prometheus (fix port expose)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -172,8 +172,8 @@ ports:
   - value: 8080
   - value: 8443
   - value: 8787
-  - value: 9779 
     expose: false
+  - value: 9779
   - value: 11211
   - value: 11222
   - value: 11333


### PR DESCRIPTION
This is an addendum to JDG-2062. It fixes mixup about ports being exposed. Prometheus port 9779 is correctly exposed and 8787 is not exposed. 