### PR TITLE
Use Data Grid 7.3 DR5 artifact; fetch artifact directly from Brew

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -222,9 +222,9 @@ packages:
     - PyYAML
     - openssl
 artifacts:
-  - path: jboss-datagrid-7.3.0-server.zip
-    description: "Pre-release artifact (DR4), not yet available on Customer Portal"
-    md5: cdd085cd3217b90546cc5420c4cb599a
+  - name: jboss-datagrid-7.3.0-server.zip
+    description: "Pre-release artifact (DR5), not yet available on Customer Portal"
+    md5: 1cb7d503003b5a3ab36ce3d129624dfd
 
 run:
   user: 185


### PR DESCRIPTION
Changing artifact specification from 'path:' to 'name:' does the trick here.
Using md5 hash is mandatory, is the only way an artifact can be queried in Brew.

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
