### PR TITLE
Use Data Grid 7.3 ER1 artifact; fetch artifact directly from Brew

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,9 +1,9 @@
 schema_version: 1
 name: jboss-datagrid-7/datagrid73-openshift
 version: 1.0
-description: Red Hat JBoss Data Grid 7.3 for OpenShift container image
+description: "Red Hat JBoss Data Grid 7.3 for OpenShift container image"
 
-from: jboss/openjdk18-rhel7:1.1
+from: rhel7:7-released
 
 labels:
   - name: "com.redhat.component"
@@ -185,6 +185,8 @@ modules:
     - name: common.modules
       path: modules/common
   install:
+    - name: jboss.container.openjdk.jdk
+      version: "8"
     - name: datagrid.distribution
     - name: dynamic-resources
     - name: s2i-common
@@ -222,7 +224,7 @@ packages:
     - PyYAML
     - openssl
 artifacts:
-  - path: jboss-datagrid-7.3.0-server.zip
+  - name: jboss-datagrid-7.3.0-server.zip
     description: "Pre-release artifact (DR4), not yet available on Customer Portal"
     md5: cdd085cd3217b90546cc5420c4cb599a
 

--- a/image.yaml
+++ b/image.yaml
@@ -225,8 +225,8 @@ packages:
     - openssl
 artifacts:
   - name: jboss-datagrid-7.3.0-server.zip
-    description: "Pre-release artifact (DR4), not yet available on Customer Portal"
-    md5: cdd085cd3217b90546cc5420c4cb599a
+    description: "Pre-release artifact (ER1), not yet available on Customer Portal"
+    md5: 9aeb544f273340dff0b8539ff0cb402c
 
 run:
   user: 185

--- a/modules/common/jboss/container/openjdk/base/configure.sh
+++ b/modules/common/jboss/container/openjdk/base/configure.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Use /dev/urandom to speed up startups.
+echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security

--- a/modules/common/jboss/container/openjdk/base/module.yaml
+++ b/modules/common/jboss/container/openjdk/base/module.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+name: jboss.container.openjdk.base
+version: 1.0
+description: "Provides image configuration common to all JBoss Java based images"
+
+# This module should eventually replace everything in jboss-container-images/jboss-openjdk-image
+
+execute:
+  - script: configure.sh
+
+modules:
+  install:
+    - name: jboss.container.user

--- a/modules/common/jboss/container/openjdk/jdk/10/module.yaml
+++ b/modules/common/jboss/container/openjdk/jdk/10/module.yaml
@@ -1,0 +1,28 @@
+schema_version: 1
+name: jboss.container.openjdk.jdk
+version: "10"
+description: "Installs the JDK for OpenJDK 10"
+
+labels:
+  - name: "org.jboss.container.product"
+    value: "openjdk"
+  - name: "org.jboss.container.product.version"
+    value: "10"
+  - name: "org.jboss.container.product.openjdk.version"
+    value: "10"
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/usr/lib/jvm/java-10"
+  - name: "JAVA_VENDOR"
+    value: "openjdk"
+  - name: "JAVA_VERSION"
+    value: "10"
+
+packages:
+  install:
+    - java-openjdk-devel-10.0.*
+
+modules:
+  install:
+    - name: jboss.container.openjdk.base

--- a/modules/common/jboss/container/openjdk/jdk/11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/modules/common/jboss/container/openjdk/jdk/11/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-Xlog:gc::utctime -XX:NativeMemoryTracking=summary"
+}

--- a/modules/common/jboss/container/openjdk/jdk/11/configure.sh
+++ b/modules/common/jboss/container/openjdk/jdk/11/configure.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+# As of rhel 7.6, rh-maven35 pulls in jdk8, so we need to remove them
+# XXX: This code should eventually move to the maven module, once layering is fully supported in cekit, as this module
+# would be installed before maven (i.e. there's nothing to remove when this module is installed)
+if [ -n "$(yum list installed java-1.8.0-openjdk-devel |grep java-1.8.0-openjdk-devel)" ]; then
+    rpm -e --nodeps java-1.8.0-openjdk-devel
+fi
+
+if [ -n "$(yum list installed java-1.8.0-openjdk-headless |grep java-1.8.0-openjdk-headless)" ]; then
+    rpm -e --nodeps java-1.8.0-openjdk-headless
+fi
+
+if [ -n "$(yum list installed java-1.8.0-openjdk |grep java-1.8.0-openjdk)" ]; then
+    rpm -e --nodeps java-1.8.0-openjdk
+fi
+
+# Update securerandom.source for quicker starts (must be done after removing jdk 8, or it will hit the wrong files)
+JAVA_SECURITY_FILE=/usr/lib/jvm/java/conf/security/java.security
+SECURERANDOM=securerandom.source
+if grep -q "^$SECURERANDOM=.*" $JAVA_SECURITY_FILE; then
+    sed -i "s|^$SECURERANDOM=.*|$SECURERANDOM=file:/dev/urandom|" $JAVA_SECURITY_FILE
+else
+    echo $SECURERANDOM=file:/dev/urandom >> $JAVA_SECURITY_FILE
+fi

--- a/modules/common/jboss/container/openjdk/jdk/11/module.yaml
+++ b/modules/common/jboss/container/openjdk/jdk/11/module.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+name: jboss.container.openjdk.jdk
+version: "11"
+description: "Installs the JDK for OpenJDK 11"
+
+labels:
+  - name: "org.jboss.product"
+    value: "openjdk"
+  - name: "org.jboss.product.version"
+    value: "11.0"
+  - name: "org.jboss.product.openjdk.version"
+    value: "11.0"
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/usr/lib/jvm/java-11"
+  - name: "JAVA_VENDOR"
+    value: "openjdk"
+  - name: "JAVA_VERSION"
+    value: "11.0"
+  - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+    value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+    - java-11-openjdk-devel
+
+modules:
+  install:
+    - name: jboss.container.user
+
+execute:
+  - script: configure.sh

--- a/modules/common/jboss/container/openjdk/jdk/8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
+++ b/modules/common/jboss/container/openjdk/jdk/8/artifacts/opt/jboss/container/openjdk/jdk/jvm-options
@@ -1,0 +1,10 @@
+
+#!/bin/sh
+# ==============================================================================
+# JDK specific customizations
+#
+# ==============================================================================
+
+function jvm_specific_diagnostics() {
+    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+}

--- a/modules/common/jboss/container/openjdk/jdk/8/configure.sh
+++ b/modules/common/jboss/container/openjdk/jdk/8/configure.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+chmod ug+x ${ARTIFACTS_DIR}/opt/jboss/container/openjdk/jdk/*
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd
+
+echo securerandom.source=file:/dev/urandom >> /usr/lib/jvm/java/jre/lib/security/java.security

--- a/modules/common/jboss/container/openjdk/jdk/8/module.yaml
+++ b/modules/common/jboss/container/openjdk/jdk/8/module.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+name: jboss.container.openjdk.jdk
+version: "8"
+description: "Installs the JDK for OpenJDK 8"
+
+labels:
+  - name: "org.jboss.product"
+    value: "openjdk"
+  - name: "org.jboss.product.version"
+    value: "1.8.0"
+  - name: "org.jboss.product.openjdk.version"
+    value: "1.8.0"
+
+envs:
+  - name: "JAVA_HOME"
+    value: "/usr/lib/jvm/java-1.8.0"
+  - name: "JAVA_VENDOR"
+    value: "openjdk"
+  - name: "JAVA_VERSION"
+    value: "1.8.0"
+  - name: JBOSS_CONTAINER_OPENJDK_JDK_MODULE
+    value: /opt/jboss/container/openjdk/jdk
+
+packages:
+  install:
+    - java-1.8.0-openjdk-devel
+
+modules:
+  install:
+    - name: jboss.container.user
+
+execute:
+  - script: configure.sh

--- a/modules/common/os-eap-logging/configure.sh
+++ b/modules/common/os-eap-logging/configure.sh
@@ -16,6 +16,6 @@ JBOSS_LOGGING_DIR="$(dirname $JBOSS_LOGGING_JAR)"
 BASE_LAYER_PATH="${JBOSS_HOME}/modules/system/layers/base/org/jboss/logmanager/ext/main/"
 
 mkdir -p $BASE_LAYER_PATH
-cp -p ${SOURCES_DIR}/javax.json-1.0.4.jar $BASE_LAYER_PATH
+cp -p ${SOURCES_DIR}/javax.json-1.0.4.redhat-1.jar $BASE_LAYER_PATH
 cp -p ${SOURCES_DIR}/jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar $BASE_LAYER_PATH
 sed -i 's|org.jboss.logmanager|org.jboss.logmanager.ext|' $JBOSS_LOGGING_DIR/module.xml

--- a/modules/common/os-eap-logging/module.yaml
+++ b/modules/common/os-eap-logging/module.yaml
@@ -8,7 +8,7 @@ execute:
     user: '185'
 
 artifacts:
-  - path: javax.json-1.0.4.jar
-    md5: 569870f975deeeb6691fcb9bc02a9555
-  - path: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
+  - url: https://maven.repository.redhat.com/ga/org/glassfish/javax.json/1.0.4.redhat-1/javax.json-1.0.4.redhat-1.jar
+    md5: 2bfa4e10093a30d7132c220de8419d75
+  - name: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
     md5: 3c84f54725ea5657913cf6d1610798b0

--- a/modules/common/os-eap7-ping/module.yaml
+++ b/modules/common/os-eap7-ping/module.yaml
@@ -25,11 +25,11 @@ envs:
     description: "Clustering labels selector."
 
 artifacts:
-  - path: openshift-ping-common-1.2.1.Final-redhat-1.jar
+  - name: openshift-ping-common-1.2.1.Final-redhat-1.jar
     md5: 7a6db2d84d9c6326363522f97f2d0f05
-  - path: openshift-ping-dns-1.2.1.Final-redhat-1.jar
+  - name: openshift-ping-dns-1.2.1.Final-redhat-1.jar
     md5: fbd94724882e9ad41d1c4db52875b8d4
-  - path: openshift-ping-kube-1.2.1.Final-redhat-1.jar
+  - name: openshift-ping-kube-1.2.1.Final-redhat-1.jar
     md5: adb78556f8d3b0f22da6d6e5d446d059
-  - path: oauth-20100527.jar
+  - name: oauth-20100527.jar
     md5: 91c7c70579f95b7ddee95b2143a49b41


### PR DESCRIPTION
Changing artifact specification from "path:" to "name:" does the trick here
Using md5 hash is mandatory, is the only way an artifact can be queried for in Brew
Includes changes for CLOUD-2970 Move base layer of JDG image from jboss-openjdk to rhel7

- Bypass CE cacher to fetch the server artifact directly from Brew
- Bypass CE cacher to fetch the os-eap7-ping module artifacts directly from Brew
- Bypass CE cacher to fetch the os-eap-logging module artifacts directly from Brew/Maven

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
