### PR TITLE
JDG-2062 Export Data Grid stats to Prometheus (Prometheus off by default)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -51,7 +51,7 @@ envs:
   - name: "DEFAULT_ADMIN_USERNAME"
     value: "jdgadmin"
   - name: "AB_PROMETHEUS_ENABLE"
-    value: "true"
+    value: "false"
     description: "Enable the use of the Prometheus agent"
   - name: "AB_PROMETHEUS_JMX_EXPORTER_PORT"
     value: "9779"


### PR DESCRIPTION
More details at https://issues.jboss.org/browse/JDG-2062 The decision to turn off Prometheus by default made by Pedro, Pavel and Vladimir
