### PR TITLE
JDG-2438 Use service certificates for the right service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,7 @@ test-cache-service-manually:
 	-p APPLICATION_PASSWORD=test \
 	-p IMAGE=$(_DEV_IMAGE_STREAM) \
 	-e SCRIPT_DEBUG=true
-	oc expose svc/cache-service-https || true
-	oc expose svc/cache-service-hotrod || true
+	oc expose svc/cache-service || true
 	oc get routes
 .PHONY: test-cache-service-manually
 
@@ -209,8 +208,7 @@ test-datagrid-service-manually:
 	-p APPLICATION_PASSWORD=test \
 	-p IMAGE=$(_DEV_IMAGE_STREAM) \
 	-e SCRIPT_DEBUG=true
-	oc expose svc/datagrid-service-https || true
-	oc expose svc/datagrid-service-hotrod || true
+	oc expose svc/datagrid-service || true
 	oc get routes
 .PHONY: test-datagrid-service-manually
 

--- a/docs/datagrid-service.asciidoc
+++ b/docs/datagrid-service.asciidoc
@@ -21,7 +21,6 @@ The command output shows the resources that the template creates, as follows:
 [source,bash,options=nowrap]
 ----
 secret "datagrid-service" created
-service "datagrid-service-headless" created
 service "datagrid-service-ping" created
 service "datagrid-service" created
 statefulset "datagrid-service" created

--- a/docs/datagrid-service.asciidoc
+++ b/docs/datagrid-service.asciidoc
@@ -23,7 +23,6 @@ The command output shows the resources that the template creates, as follows:
 secret "datagrid-service" created
 service "datagrid-service-headless" created
 service "datagrid-service-ping" created
-service "datagrid-service-https" created
-service "datagrid-service-hotrod" created
+service "datagrid-service" created
 statefulset "datagrid-service" created
 ----

--- a/services/cache-service-template.yaml
+++ b/services/cache-service-template.yaml
@@ -30,18 +30,6 @@ objects:
   kind: Service
   metadata:
     annotations:
-      description: Provides a headless service for the StatefulSet.
-    labels:
-      application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-headless
-  spec:
-    clusterIP: None
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
       description: Provides a ping service for clustered applications.
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     labels:
@@ -81,7 +69,7 @@ objects:
     name: ${APPLICATION_NAME}
   spec:
     replicas: ${{NUMBER_OF_INSTANCES}}
-    serviceName: ${APPLICATION_NAME}-headless
+    serviceName: ${APPLICATION_NAME}-ping
     strategy:
       type: Rolling
       rollingParams:

--- a/services/cache-service-template.yaml
+++ b/services/cache-service-template.yaml
@@ -31,19 +31,11 @@ objects:
   metadata:
     annotations:
       description: Provides a headless service for the StatefulSet.
-      service.alpha.openshift.io/serving-cert-secret-name: service-certs
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-headless
   spec:
     clusterIP: None
-    ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
-    - name: hotrod
-      port: 11222
-      targetPort: 11222
     selector:
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: v1
@@ -66,28 +58,19 @@ objects:
   kind: Service
   metadata:
     annotations:
-      description: Provides a service for accessing the application over HTTPS.
+      description: Provides a service for accessing the application over HTTPS or Hot Rod protocol.
+      service.alpha.openshift.io/serving-cert-secret-name: service-certs
     labels:
       application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-https
+    name: ${APPLICATION_NAME}
   spec:
     ports:
-    - port: 8080
-      targetPort: 8443
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      description: Provides a service for accessing the application through the Hot Rod protocol.
-    labels:
-      application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-hotrod
-  spec:
-    ports:
-    - port: 11222
+    - name: hotrod
+      port: 11222
       targetPort: 11222
+    - name: https
+      port: 8443
+      targetPort: 8443
     selector:
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: apps/v1beta1
@@ -150,8 +133,8 @@ objects:
             timeoutSeconds: 10
           name: ${APPLICATION_NAME}
           ports:
-          - containerPort: 8080
-            name: http
+          - containerPort: 8443
+            name: https
             protocol: TCP
           - containerPort: 8888
             name: ping

--- a/services/datagrid-service-template.yaml
+++ b/services/datagrid-service-template.yaml
@@ -36,13 +36,6 @@ objects:
     name: ${APPLICATION_NAME}-headless
   spec:
     clusterIP: None
-    ports:
-    - name: https
-      port: 8443
-      targetPort: 8443
-    - name: hotrod
-      port: 11222
-      targetPort: 11222
     selector:
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: v1

--- a/services/datagrid-service-template.yaml
+++ b/services/datagrid-service-template.yaml
@@ -30,18 +30,6 @@ objects:
   kind: Service
   metadata:
     annotations:
-      description: Provides a headless service for the StatefulSet.
-    labels:
-      application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-headless
-  spec:
-    clusterIP: None
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
       description: Provides a ping service for clustered applications.
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     labels:
@@ -81,7 +69,7 @@ objects:
     name: ${APPLICATION_NAME}
   spec:
     replicas: ${{NUMBER_OF_INSTANCES}}
-    serviceName: ${APPLICATION_NAME}-headless
+    serviceName: ${APPLICATION_NAME}-ping
     strategy:
       rollingParams:
         intervalSeconds: 20

--- a/services/datagrid-service-template.yaml
+++ b/services/datagrid-service-template.yaml
@@ -38,9 +38,9 @@ objects:
   spec:
     clusterIP: None
     ports:
-    - name: http
-      port: 8080
-      targetPort: 8080
+    - name: https
+      port: 8443
+      targetPort: 8443
     - name: hotrod
       port: 11222
       targetPort: 11222
@@ -72,7 +72,7 @@ objects:
     name: ${APPLICATION_NAME}-https
   spec:
     ports:
-    - port: 8080
+    - port: 8443
       targetPort: 8443
     selector:
       deploymentConfig: ${APPLICATION_NAME}
@@ -146,8 +146,8 @@ objects:
             timeoutSeconds: 10
           name: ${APPLICATION_NAME}
           ports:
-          - containerPort: 8080
-            name: http
+          - containerPort: 8443
+            name: https
             protocol: TCP
           - containerPort: 8888
             name: ping

--- a/services/datagrid-service-template.yaml
+++ b/services/datagrid-service-template.yaml
@@ -31,7 +31,6 @@ objects:
   metadata:
     annotations:
       description: Provides a headless service for the StatefulSet.
-      service.alpha.openshift.io/serving-cert-secret-name: service-certs
     labels:
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-headless
@@ -66,28 +65,19 @@ objects:
   kind: Service
   metadata:
     annotations:
-      description: Provides a service for accessing the application over HTTPS.
+      description: Provides a service for accessing the application over HTTPS or Hot Rod protocol.
+      service.alpha.openshift.io/serving-cert-secret-name: service-certs
     labels:
       application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-https
+    name: ${APPLICATION_NAME}
   spec:
     ports:
-    - port: 8443
-      targetPort: 8443
-    selector:
-      deploymentConfig: ${APPLICATION_NAME}
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      description: Provides a service for accessing the application through the Hot Rod protocol.
-    labels:
-      application: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}-hotrod
-  spec:
-    ports:
-    - port: 11222
+    - name: hotrod
+      port: 11222
       targetPort: 11222
+    - name: https
+      port: 8443
+      targetPort: 8443
     selector:
       deploymentConfig: ${APPLICATION_NAME}
 - apiVersion: apps/v1beta1

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/caching/CachingServiceTest.java
@@ -66,7 +66,7 @@ public class CachingServiceTest {
    @Before
    public void before() throws MalformedURLException {
       readinessCheck.waitUntilAllPodsAreReady();
-      restService = handle.getServiceWithName(SERVICE_NAME + "-https");
+      restService = handle.getServiceWithName(SERVICE_NAME);
    }
 
    @Test

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/datagrid/DatagridServiceTest.java
@@ -53,7 +53,7 @@ public class DatagridServiceTest {
    @Before
    public void before() throws MalformedURLException {
       readinessCheck.waitUntilAllPodsAreReady();
-      restService = handle.getServiceWithName(SERVICE_NAME + "-https");
+      restService = handle.getServiceWithName(SERVICE_NAME);
    }
 
    @Test

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodConfiguration.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/endpoint/HotRodConfiguration.java
@@ -30,7 +30,7 @@ public class HotRodConfiguration {
       return svcName -> {
          final ConfigurationBuilder config = new ConfigurationBuilder();
 
-         final URL url = getServiceWithName(svcName + "-hotrod");
+         final URL url = getServiceWithName(svcName);
          TrustStore trustStore = new TrustStore(svcName);
 
          config

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftHandle.java
@@ -24,7 +24,7 @@ public class OpenShiftHandle {
             host = spec.getClusterIP();
          }
          //use HTTP as the protocol is unimportant and we don't want to register custom handlers
-         return new URL(HTTP_PROTOCOL, host, spec.getPorts().get(0).getPort(), "/");
+         return new URL(HTTP_PROTOCOL, host, 8443, "/");
       }
       return null;
    }

--- a/services/functional-tests/src/test/resources/arquillian.xml
+++ b/services/functional-tests/src/test/resources/arquillian.xml
@@ -31,7 +31,7 @@
            Note: The EAP pod has to have DEBUG=true in the yaml definition so that EAP start in debug mode
         -->
         <property name="definitionsFile">target/classes/eap7-testrunner.yaml</property>
-        <property name="wait.for.service.list">cache-service-hotrod, cache-service-https, datagrid-service-hotrod, datagrid-service-https</property>
+        <property name="wait.for.service.list">cache-service, datagrid-service</property>
         <property name="env.script.env">image=${image}</property>
         <property name="proxiedContainerPorts">testrunner:9990</property>
         <!-- Fetch the logs from Openshift and pods, and save them into target/surefire-reports -->


### PR DESCRIPTION
Let's start by clarifying a few things:
* Headless service is designed for JGroups' DNS ping functionality. No service certificates should be applied to that, nor should it expose HTTPs or Hot Rod protocols. It's just there for name resolution of the pods for DNS ping to do its magic.
* Service certificates are designed to be applied to a single service since they pick the service's name as CN, and from what I've gathered, the hostnames for these certificates cannot be modified (you can for a user defined secret).

With that in mind, I've done the following:
* Remove all 8080 port references in the template. We only expose HTTPs port, secured and encrypted out of the box. That was agreed.
* Fixes so that all HTTPs references are linked to port 8443.
* Merge `cache|datagrid-service-hotrod` and `cache|datagrid-service-https` services into a single service called `cache|datagrid-service` which exposes two ports: `8443` and `11222`.
* Assign `service-certs` to `cache|datagrid-service` service. 

As a side note, this won't fix [JDG-2446](https://issues.jboss.org/browse/JDG-2446). The problem there is that when accessed externally, the host name does not match the server's certificate CN. Pavel had some ideas on how that could be fixed at the tutorial level.