### PR TITLE
Remove hardcoded namespace

### DIFF
--- a/services/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftClientCreator.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/utils/OpenShiftClientCreator.java
@@ -1,16 +1,11 @@
 package org.infinispan.online.service.utils;
 
-import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 public class OpenShiftClientCreator {
 
-   //TODO: Get namespace and username from env properties
-   private static final OpenShiftClient CLIENT = new DefaultOpenShiftClient(new ConfigBuilder()
-         .withNamespace("myproject")
-         .withUsername("developer")  //auth token is read from environment property KUBERNETES_AUTH_TOKEN
-         .build());
+   private static final OpenShiftClient CLIENT = new DefaultOpenShiftClient();
 
    private OpenShiftClientCreator() {
    }


### PR DESCRIPTION
Hard-coded namespace makes impossible to run tests in other namespace. This makes impossible to run tests in shared Online environment where such namespace with such name already exist under another user.

Dropping namespace from configuration results in namespace property to be instantiated from `/var/run/secrets/kubernetes.io/serviceaccount/namespace` file if exist. (Thus this wouldn't be sufficient solution if this class would be used outside of OpenShift, but this isn't a case atm.)

Username property can be also dropped as that property is already part of token.