### PR TITLE
[JDG-2062] Export Data Grid stats to Prometheus (Prometheus env vars)

### DIFF
--- a/templates/datagrid73-basic.json
+++ b/templates/datagrid73-basic.json
@@ -134,6 +134,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "description": "Container memory limit",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
@@ -341,6 +348,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -434,6 +446,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-https.json
+++ b/templates/datagrid73-https.json
@@ -204,6 +204,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "description": "Container memory limit",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
@@ -470,6 +477,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -612,6 +624,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-mysql-persistent.json
+++ b/templates/datagrid73-mysql-persistent.json
@@ -289,6 +289,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "displayName": "MySQL Image Stream Tag",
             "description": "The tag to use for the \"mysql\" image stream.  Typically, this aligns with the major.minor version of MySQL.",
             "name": "MYSQL_IMAGE_STREAM_TAG",
@@ -590,6 +597,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -784,6 +796,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-mysql.json
+++ b/templates/datagrid73-mysql.json
@@ -289,6 +289,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "description": "Container memory limit",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
@@ -583,6 +590,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -777,6 +789,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-partition.json
+++ b/templates/datagrid73-partition.json
@@ -134,6 +134,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "displayName": "Datagrid Volume Size",
             "description": "Size of the volume used by Datagrid for persisting metadata.",
             "name": "VOLUME_CAPACITY",
@@ -385,6 +392,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -487,6 +499,10 @@
                                     {
                                         "name": "DATAGRID_SPLIT",
                                         "value": "${DATAGRID_SPLIT}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-postgresql-persistent.json
+++ b/templates/datagrid73-postgresql-persistent.json
@@ -271,6 +271,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
@@ -570,6 +577,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -764,6 +776,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }

--- a/templates/datagrid73-postgresql.json
+++ b/templates/datagrid73-postgresql.json
@@ -264,6 +264,13 @@
             "required": true
         },
         {
+            "displayName": "Enable Prometheus",
+            "description": "Enables Prometheus agent for monitoring",
+            "name": "AB_PROMETHEUS_ENABLE",
+            "value": "true",
+            "required": false
+        },
+        {
             "displayName": "PostgreSQL Image Stream Tag",
             "description": "The tag to use for the \"postgresql\" image stream.  Typically, this aligns with the major.minor version of PostgreSQL.",
             "name": "POSTGRESQL_IMAGE_STREAM_TAG",
@@ -563,6 +570,11 @@
                                         "protocol": "TCP"
                                     },
                                     {
+                                        "name": "prometheus",
+                                        "containerPort": 9779,
+                                        "protocol": "TCP"
+                                    },
+                                    {
                                         "name": "http",
                                         "containerPort": 8080,
                                         "protocol": "TCP"
@@ -757,6 +769,10 @@
                                     {
                                         "name": "JGROUPS_CLUSTER_PASSWORD",
                                         "value": "${JGROUPS_CLUSTER_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "AB_ENABLE_PROMETHEUS",
+                                        "value": "${AB_ENABLE_PROMETHEUS}"
                                     }
                                 ]
                             }


### PR DESCRIPTION
Update all templates to include `AB_ENABLE_PROMETHEUS` env var along with port declaration and env var description. For more details see https://issues.jboss.org/browse/JDG-2062