### PR TITLE
[JDG-2405] Setting Environment for JDG security will end up in wrong c0nfiguration or invalid XML file

### DIFF
--- a/modules/datagrid/launch/added/launch/infinispan-config.sh
+++ b/modules/datagrid/launch/added/launch/infinispan-config.sh
@@ -599,13 +599,15 @@ function get_db_type() {
 function configure_container_security() {
   if [ -n "$CONTAINER_SECURITY_ROLE_MAPPER$CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS$CONTAINER_SECURITY_ROLES" ]; then
     if [ -n "$CONTAINER_SECURITY_ROLE_MAPPER" ]; then
+      local rolemapper="\
+                        <$CONTAINER_SECURITY_ROLE_MAPPER />"
+
       if [ -n "$CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS" ] && [ "$CONTAINER_SECURITY_ROLE_MAPPER" == "custom-role-mapper" ]; then
         local CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS="class=\"$CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS\""
+        rolemapper="\
+                    <$CONTAINER_SECURITY_ROLE_MAPPER $CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS/>"
       fi
-      local rolemapper="\
-                        <$CONTAINER_SECURITY_ROLE_MAPPER $CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS/>"
     fi
-
     if [ -z "$rolemapper" ]; then
       rolemapper="<identity-role-mapper />"
     fi


### PR DESCRIPTION
Do not integrate yet as I am verifying all permutations and effects with an actual image. See https://issues.jboss.org/browse/JDG-2405 for more details. 

In the PR proposal, we only set custom role mapper and its class if and only if both CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS and CONTAINER_SECURITY_ROLE_MAPPER are specified and CONTAINER_SECURITY_ROLE_MAPPER == ''custom-role-mapper". In other cases, we don't verify that CONTAINER_SECURITY_ROLE_MAPPER is one of the existing role mappers: identity-role-mapper, common-name-role-mapper, cluster-role-mapper, or custom-role-mapper. We rely on the user to properly pass the role mapper (see Pavel's argument in the above JIRA discussion). 

In case the role mapper is non-existent/invalid the server won't boot. In case, a user specifies only CONTAINER_SECURITY_CUSTOM_ROLE_MAPPER_CLASS or perhaps CONTAINER_SECURITY_ROLES but not CONTAINER_SECURITY_ROLE_MAPPER we default to identity-role-mapper. 