### PR TITLE
[JDG-2407] It should be possible to set or change Logging levels via environement

### DIFF
--- a/modules/datagrid/configuration/added/clustered-openshift.xml
+++ b/modules/datagrid/configuration/added/clustered-openshift.xml
@@ -102,15 +102,6 @@
                 <rotate-size value="10M"/>
                 <max-backup-index value="10"/>
             </size-rotating-file-handler>
-            <logger category="com.arjuna">
-                <level name="WARN"/>
-            </logger>
-            <logger category="org.jboss.as.config">
-                <level name="DEBUG"/>
-            </logger>
-            <logger category="sun.rmi">
-                <level name="WARN"/>
-            </logger>
             <logger category="org.infinispan.HOTROD_ACCESS_LOG" use-parent-handlers="false">
                 <!-- Set to TRACE to enable access logging for hot rod or use DMR -->
                 <level name="INFO"/>
@@ -118,6 +109,7 @@
                     <handler name="HR-ACCESS-FILE"/>
                 </handlers>
             </logger>
+            <!-- ##LOGGER_CONFIGURATION## -->
             <!-- ##ACCESS_LOG_HANDLER## -->
             <root-logger>
                 <level name="INFO"/>

--- a/modules/datagrid/launch/added/launch/logging.sh
+++ b/modules/datagrid/launch/added/launch/logging.sh
@@ -1,0 +1,29 @@
+function prepareEnv() {
+  unset loggers
+  unset LOGGING_CATEGORIES
+}
+
+
+function configure() {
+  if [ -n "$LOGGING_CATEGORIES" ]; then
+      IFS=',' read -a loggerlist <<< "$(find_env "CUSTOM_LOGGERS")"
+      if [ "${#loggerlist[@]}" -ne "0" ]; then
+        loggercount=0
+        while [ $loggercount -lt ${#loggerlist[@]} ]; do
+          logger="${loggerlist[$loggercount]}"
+
+          category=${logger%=*}
+          level=${logger#*=}
+          loggers+="\n            <logger category=\"$category\"><level name=\"$level\"/></logger>"
+          loggercount=$((loggercount+1))
+        done
+      fi
+  else
+    # then use default loggers
+    loggers+="\n            <logger category=\"com.arjuna\"><level name=\"WARN\"/></logger>"	 
+    loggers+="\n            <logger category=\"sun.rmi\"><level name=\"WARN\"/></logger>" 
+    loggers+="\n            <logger category=\"org.jboss.as.config\"><level name=\"DEBUG\"/></logger>" 
+  fi
+  sed -i "s|<!-- ##LOGGER_CONFIGURATION## -->|$loggers|" "$CONFIG_FILE"
+}
+

--- a/modules/datagrid/launch/added/launch/openshift-common.sh
+++ b/modules/datagrid/launch/added/launch/openshift-common.sh
@@ -25,6 +25,7 @@ if [ "${USER_CONFIG_MAP^^}" != "TRUE" ]; then
   $JBOSS_HOME/bin/launch/infinispan-config.sh
   $JBOSS_HOME/bin/launch/management-realm.sh
   $JBOSS_HOME/bin/launch/access_log_valve.sh
+  $JBOSS_HOME/bin/launch/logging.sh
   /opt/run-java/proxy-options
   )
 else

--- a/modules/datagrid/launch/configure.sh
+++ b/modules/datagrid/launch/configure.sh
@@ -29,3 +29,7 @@ cp -p ${ADDED_DIR}/launch/service-memory.conf $JBOSS_HOME/bin/launch
 
 # Append Prometheus agent to standalone.conf
 cat ${ADDED_DIR}/launch/prometheus.conf >> $JBOSS_HOME/bin/standalone.conf
+
+# Add logging config script
+cp -p ${ADDED_DIR}/launch/logging.sh $JBOSS_HOME/bin/launch
+


### PR DESCRIPTION
*Preview* of a solution for [JDG-2407](https://issues.jboss.org/browse/JDG-2407) One would add custom loggers like this:

- `docker run -e CUSTOM_LOGGERS=org.infinipan.core=WARN -it jboss-datagrid-7/datagrid73-openshift:latest` (adding only one custom loggers)

- `docker run -e CUSTOM_LOGGERS=org.infinipan.core=WARN,org.infinispan.config=DEBUG -it jboss-datagrid-7/datagrid73-openshift:latest`  (adding two loggers with different categories and levels)
