### PR TITLE
[JDG-2062] Export Data Grid stats to Prometheus

### DIFF
--- a/services/cache-service-template.yaml
+++ b/services/cache-service-template.yaml
@@ -109,6 +109,8 @@ objects:
             value: ${REPLICATION_FACTOR}
           - name: EVICTION_POLICY
             value: ${EVICTION_POLICY}
+          - name: AB_PROMETHEUS_ENABLE
+            value: true
           image: ${IMAGE}
           livenessProbe:
             exec:

--- a/services/datagrid-service-template.yaml
+++ b/services/datagrid-service-template.yaml
@@ -95,6 +95,8 @@ objects:
             value: openshift.DNS_PING
           - name: OPENSHIFT_DNS_PING_SERVICE_NAME
             value: ${APPLICATION_NAME}-ping
+          - name: AB_PROMETHEUS_ENABLE
+            value: true
           - name: USERNAME
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Preview only. Turn Prometheus on by default without additional template parameters. Advanced users, if needed, can turn it off easily by changing env variable `AB_ENABLE_PROMETHEUS` to false.   
P.S. Not sure if we need to specify Prometheus port in the ports section. Prometheus port 9779 is already exposed in the underlying image. 