### PR TITLE
Call correct logging script

### DIFF
--- a/modules/datagrid/launch/added/launch/openshift-common.sh
+++ b/modules/datagrid/launch/added/launch/openshift-common.sh
@@ -25,7 +25,7 @@ if [ "${USER_CONFIG_MAP^^}" != "TRUE" ]; then
   $JBOSS_HOME/bin/launch/infinispan-config.sh
   $JBOSS_HOME/bin/launch/management-realm.sh
   $JBOSS_HOME/bin/launch/access_log_valve.sh
-  $JBOSS_HOME/bin/launch/logging.sh
+  $JBOSS_HOME/bin/launch/infinispan-logging.sh
   /opt/run-java/proxy-options
   )
 else


### PR DESCRIPTION
Script responsible for logging configuration is called `infinispan-logging.sh`. `logging.sh` is reponsible for standardizing log messages.