### PR TITLE
[WIP] Change JDK version to use Java 11

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -186,7 +186,7 @@ modules:
       path: modules/common
   install:
     - name: jboss.container.openjdk.jdk
-      version: "8"
+      version: "11"
     - name: datagrid.distribution
     - name: dynamic-resources
     - name: s2i-common

--- a/modules/common/jolokia/added/standalone.conf
+++ b/modules/common/jolokia/added/standalone.conf
@@ -11,4 +11,4 @@ export AB_JOLOKIA_PORT
 # add jolokia options
 JAVA_OPTS="${JAVA_OPTS} $(/opt/jolokia/jolokia-opts)"
 
-JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/p:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_LOGMANAGER_EXT_JAR}:${WILDFLY_COMMON_JAR} -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/a:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_LOGMANAGER_EXT_JAR}:${WILDFLY_COMMON_JAR} -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dsun.util.logging.disableCallerCheck=true"


### PR DESCRIPTION
UPDATED
~Built on top of #174, so it includes both Data Grid 7.3.1.CR1 and JDK 11 changes~
~Built on top of #176, so it includes both Data Grid 7.3.1.CR2 and JDK 11 changes~
Built on top of #177, so it includes both Data Grid 7.3.1.CR3 and JDK 11 changes

As (somewhat) expected, changing from JDK 8 to JDK 11 caused some issues with unsupported features

The image can be built, but when trying to do a simple test using `docker run`, the following error occurs:
https://pastebin.com/6rv9X2te (updated)

Got some ideas from here: https://github.com/jboss-container-images/jboss-eap-modules/pull/69
(our modules came from the same place as those, so it makes sense to look at how EAP folks have dealt with JDK 11)

Points worth noticing:
1. `-Xbootclasspath/p:` (prepend on classpath) is not supported anymore, was changed to `-Xbootclasspath/a:` (append on classpath)
2. Added `-Dsun.util.logging.disableCallerCheck=true` for the LogManager configuration
3. Keeping the `JBOSS_MODULES_JAR` in the Jolokia configuration yelds a warning about an illegal reflective access operation; excluding `JBOSS_MODULES_JAR` yelds an error on loading `logmanager.ext` module (and a different warning about an illegal reflective access operation, in other module)
4. The error booting the container is `java.lang.NoClassDefFoundError: javax/sql/DataSource`. This is what I'm working on now

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
