### PR TITLE
Enable s390x builds only - disable x86_64

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -1,4 +1,3 @@
 platforms:
   only:
-    - x86_64
     - s390x


### PR DESCRIPTION
It can be enabled locally, should we need to debug something on Intel platforms (x86_64).
