### PR TITLE
Run tests with eap73

### DIFF
--- a/services/functional-tests/pom.xml
+++ b/services/functional-tests/pom.xml
@@ -16,7 +16,6 @@
         <arquillian-cube-openshift.version>1.17.1</arquillian-cube-openshift.version>
         <assertj-core.version>3.11.1</assertj-core.version>
         <jetty-client.version>9.4.12.v20180830</jetty-client.version>
-        <version.chameleon>1.0.0.CR2</version.chameleon>
         <org.apache.maven.user-settings>maven-settings.xml</org.apache.maven.user-settings>
         <wildfly-creaper-core.version>1.1.0</wildfly-creaper-core.version>
     </properties>
@@ -41,6 +40,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>2.1.1.Final</version>
+            <scope>test</scope>
+        </dependency>
         <!-- https://github.com/arquillian/arquillian-cube/blob/master/docs/kubernetes.adoc#dealing-with-version-conflicts -->
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -90,12 +95,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.arquillian.container</groupId>
-            <artifactId>arquillian-container-chameleon</artifactId>
-            <version>${version.chameleon}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/scaling/ScalingTester.java
@@ -14,7 +14,7 @@ public class ScalingTester {
 
    public void scaleDownStatefulSet(int numReplicas, String statefulSetName) {
       CommandLine.scaleStatefulSet(statefulSetName, numReplicas);
-      READINESS_CHECK.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, 1);
+      READINESS_CHECK.waitUntilTargetNumberOfReplicasAreReady(statefulSetName, numReplicas);
    }
 
 }

--- a/services/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
+++ b/services/functional-tests/src/test/java/org/infinispan/online/service/utils/ReadinessCheck.java
@@ -1,5 +1,6 @@
 package org.infinispan.online.service.utils;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -42,7 +43,7 @@ public class ReadinessCheck {
 
          if (numReady + numNotReady == numAll) {
             log.infof("Expected %d pods to be ready, but %d are not ready (all pods are %d)", numReady, numNotReady, numAll);
-            log.infof("Not ready: %s", notReadyPods);
+            log.infof("Not ready: %s", Arrays.toString(notReadyPods.stream().map(p -> p.getMetadata().getName()).toArray()));
             return notReadyPods.isEmpty();
          }
 
@@ -66,7 +67,7 @@ public class ReadinessCheck {
 
          if (numReady != expectedNumPods) {
             log.infof("Expected %d pods to be ready: ready=%d,notReady=%d,all=%d", expectedNumPods, numReady, numNotReady, numAll);
-            log.infof("Not ready: %s", notReadyPods);
+            log.infof("Not ready: %s", Arrays.toString(notReadyPods.stream().map(p -> p.getMetadata().getName()).toArray()));
 
             if (numReady + numNotReady != expectedNumPods) {
                log.infof("There is a mismatch between ready and not ready Pods. numberReadyPods=%d, numberNotReadyPods=%d, numUnknown=%d, numberAllPods=%d", numReady, numNotReady, numUnknown, numAll);

--- a/services/functional-tests/src/test/resources/arquillian.xml
+++ b/services/functional-tests/src/test/resources/arquillian.xml
@@ -46,7 +46,7 @@
     <container qualifier="testrunner" mode="suite" default="true">
         <!-- Pod running remote tests. -->
         <configuration>
-            <property name="chameleonTarget">jboss eap:7.0:remote</property>
+            <property name="allowConnectingToRunningServer">true</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>

--- a/services/functional-tests/src/test/resources/eap7-testrunner.yaml
+++ b/services/functional-tests/src/test/resources/eap7-testrunner.yaml
@@ -17,10 +17,10 @@ spec:
         - "/opt/eap/bin/readinessProbe.sh"
       initialDelaySeconds: 60
       timeoutSeconds: 10
-      periodSeconds: 20
+      periodSeconds: 5
       successThreshold: 2
       failureThreshold: 5
-    image: "${DOCKER_REGISTRY_REDHAT}jboss-eap-7/eap71-openshift:1.3-10"
+    image: "${DOCKER_REGISTRY_REDHAT}rh-osbs/jboss-eap-7-eap73-openjdk11-openshift-rhel8:7.3.0"
     ports:
     - containerPort: 8080
       protocol: TCP


### PR DESCRIPTION
Enable test execution with EAP73, increase scaling tests stability:
* Update to testrunner eap73
* Changes the container manager from chameleon to wildfly-managed
* Fixes scale method to expect correct number of pod
* Prints only not-ready pods names instead their whole json spec
* Lower readiness check period on eap pod to speed up manual testing a bit
