### PR TITLE
JDG-3952 Updates for releasing Data Grid 7.3 OpenShift image v1.7 (7.3.7)

### DIFF
--- a/templates/datagrid73-basic.json
+++ b/templates/datagrid73-basic.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -290,7 +290,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-https.json
+++ b/templates/datagrid73-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -407,7 +407,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-image-stream.json
+++ b/templates/datagrid73-image-stream.json
@@ -17,7 +17,7 @@
                 "annotations": {
                     "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3",
                     "openshift.io/provider-display-name": "Red Hat, Inc.",
-                    "version": "1.6"
+                    "version": "1.7"
                 }
             },
             "spec": {
@@ -146,6 +146,24 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.6"
+                        }
+                    },
+                    {
+                        "name": "1.7",
+                        "annotations": {
+                            "description": "Red Hat JBoss Data Grid 7.3 image",
+                            "iconClass": "icon-datagrid",
+                            "tags": "datagrid,jboss,hidden",
+                            "supports": "datagrid:7.3",
+                            "version": "1.7",
+                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.7"
                         }
                     }
                 ]

--- a/templates/datagrid73-mysql-persistent.json
+++ b/templates/datagrid73-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + MySQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -527,7 +527,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-mysql.json
+++ b/templates/datagrid73-mysql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + MySQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -520,7 +520,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-partition.json
+++ b/templates/datagrid73-partition.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -328,7 +328,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-postgresql-persistent.json
+++ b/templates/datagrid73-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + PostgreSQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -507,7 +507,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },

--- a/templates/datagrid73-postgresql.json
+++ b/templates/datagrid73-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.6",
+            "version": "1.7",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + PostgreSQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -500,7 +500,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.6"
+                                "name": "jboss-datagrid73-openshift:1.7"
                             }
                         }
                     },


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-3952

Updates the image stream and the legacy templates.
