### PR TITLE
Change the base image to be the latest released rhel7

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ name: jboss-datagrid-7/datagrid73-openshift
 version: 1.8
 description: "Red Hat JBoss Data Grid 7.3 for OpenShift container image"
 
-from: rhel7:7.9-243
+from: registry.redhat.io/rhel7
 
 labels:
   - name: "com.redhat.component"


### PR DESCRIPTION
Explicitly uses the external registry; always pulls the latest tag
