### PR TITLE
Fix image streams to use the correct OpenJ9 repo; update legacy templates to use latest image stream

### DIFF
--- a/templates/datagrid73-basic.json
+++ b/templates/datagrid73-basic.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -290,7 +290,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-https.json
+++ b/templates/datagrid73-https.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -407,7 +407,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-image-stream.json
+++ b/templates/datagrid73-image-stream.json
@@ -23,114 +23,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.1"
-                        }
-                    },
-                    {
-                        "name": "1.2",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.2",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.2"
-                        }
-                    },
-                    {
-                        "name": "1.3",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.3",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3"
-                        }
-                    },
-                    {
-                        "name": "1.4",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.4",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.4"
-                        }
-                    },
-                    {
-                        "name": "1.5",
-                        "annotations": {
-                            "description": "Red Hat JBoss Data Grid 7.3 image",
-                            "iconClass": "icon-datagrid",
-                            "tags": "datagrid,jboss,hidden",
-                            "supports": "datagrid:7.3",
-                            "version": "1.5",
-                            "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5"
-                        }
-                    },
-                    {
                         "name": "1.6",
                         "annotations": {
                             "description": "Red Hat JBoss Data Grid 7.3 image",
@@ -145,7 +37,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.6"
+                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openj9-11-openshift-rhel8:1.6"
                         }
                     },
                     {
@@ -163,7 +55,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.7"
+                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openj9-11-openshift-rhel8:1.7"
                         }
                     },
                     {
@@ -181,7 +73,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.8"
+                            "name": "registry.redhat.io/jboss-datagrid-7/datagrid73-openj9-11-openshift-rhel8:1.8"
                         }
                     }
                 ]

--- a/templates/datagrid73-mysql-persistent.json
+++ b/templates/datagrid73-mysql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + MySQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -527,7 +527,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-mysql.json
+++ b/templates/datagrid73-mysql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + MySQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a MySQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -520,7 +520,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-partition.json
+++ b/templates/datagrid73-partition.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 (Ephemeral, no https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -328,7 +328,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-postgresql-persistent.json
+++ b/templates/datagrid73-postgresql-persistent.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + PostgreSQL (with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -507,7 +507,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },

--- a/templates/datagrid73-postgresql.json
+++ b/templates/datagrid73-postgresql.json
@@ -5,7 +5,7 @@
         "annotations": {
             "iconClass": "icon-datagrid",
             "tags": "datagrid,jboss,hidden",
-            "version": "1.4",
+            "version": "1.8",
             "openshift.io/display-name": "Red Hat JBoss Data Grid 7.3 + PostgreSQL (Ephemeral with https)",
             "openshift.io/provider-display-name": "Red Hat, Inc.",
             "description": "An example Red Hat JBoss Data Grid application with a PostgreSQL database. For more information about using this template, see https://github.com/jboss-openshift/application-templates.",
@@ -500,7 +500,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "jboss-datagrid73-openshift:1.4"
+                                "name": "jboss-datagrid73-openshift:1.8"
                             }
                         }
                     },


### PR DESCRIPTION
- Removed image streams from 1.0 to 1.5, since those versions were never released for OpenJ9
- The image streams were referencing the Intel tag; fixed
- Tagging `7.3-v1.8-openj9` (right after merging)

@mdrafiur, please, take a look and ask questions you might have; if you are ok with it, I'm merging and tagging `7.3-v1.8-openj9`. Thanks.